### PR TITLE
Add CarouselContext for Stage 8 carousel navigation

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -2359,3 +2359,51 @@ All Stage 5 (Launch) code issues are now closed:
 - `npm run lint` - passes with no errors
 - `npm run build` - successful production build
 - `npm test` - 1840 passed (pre-existing test failures unrelated to this change)
+
+### 2026-01-18 - Issue #127: B2: CarouselContext
+
+**Completed:**
+- Created `/src/components/carousel/CarouselContext.tsx` with full state management
+- Implemented `CarouselProvider` component with:
+  - State tracking: currentIndex, items array, completedItems, isPaused, lastDirection
+  - Navigation methods: next(), prev(), goTo(), pause(), resume(), markComplete()
+  - Derived values: currentItem, progress, totalItems, completedCount, isFirstItem, isLastItem, isAtPaywall
+  - Paywall support: canGoNext/canGoPrev respect paywallIndex and hasPremiumAccess
+- Implemented localStorage persistence:
+  - Key format: `carousel-{companySlug}-{roleSlug}`
+  - Saves on every state change
+  - Loads saved position on mount
+- Implemented Supabase sync:
+  - Uses existing `journey_progress` table with journeyId format `carousel-{company}-{role}`
+  - Debounced save (1 second) for performance
+  - Loads from Supabase on mount if remote state is newer
+  - Configurable via `enableSupabaseSync` prop (default: true)
+- Created `useCarousel()` hook for consuming context
+- Created index.ts for exports
+
+**Files Created:**
+- `src/components/carousel/CarouselContext.tsx`
+- `src/components/carousel/index.ts`
+- `src/components/carousel/__tests__/CarouselContext.test.tsx`
+
+**Tests:**
+- 53 unit tests covering:
+  - Initialization (7 tests)
+  - Navigation next/prev/goTo (11 tests)
+  - markComplete (3 tests)
+  - pause/resume (2 tests)
+  - progress calculation (2 tests)
+  - canGoNext/canGoPrev (4 tests)
+  - Paywall behavior (8 tests)
+  - localStorage persistence (4 tests)
+  - useCarousel outside provider (1 test)
+  - Rendering (2 tests)
+  - Supabase sync integration (3 tests)
+  - isFirstItem/isLastItem (4 tests)
+  - Empty items handling (2 tests)
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - 53 new carousel tests pass (1893 total passed, 12 pre-existing failures unrelated to this change)

--- a/src/components/carousel/CarouselContext.tsx
+++ b/src/components/carousel/CarouselContext.tsx
@@ -1,0 +1,433 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import type {
+  CarouselItem,
+  CarouselState,
+  CarouselContextValue,
+  CarouselOptions,
+  CarouselProgress,
+  CarouselDirection,
+} from "@/types";
+import { createBrowserClient } from "@/lib/supabase/client";
+
+const CarouselContext = createContext<CarouselContextValue | null>(null);
+
+/** Get localStorage key for carousel progress */
+function getStorageKey(companySlug: string, roleSlug: string): string {
+  return `carousel-${companySlug}-${roleSlug}`;
+}
+
+/** Load carousel progress from localStorage */
+function loadPersistedProgress(
+  companySlug: string,
+  roleSlug: string
+): CarouselProgress | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const stored = localStorage.getItem(getStorageKey(companySlug, roleSlug));
+    if (!stored) return null;
+
+    const progress = JSON.parse(stored) as CarouselProgress;
+    return progress;
+  } catch {
+    return null;
+  }
+}
+
+/** Save carousel progress to localStorage */
+function persistProgress(progress: CarouselProgress): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    localStorage.setItem(
+      getStorageKey(progress.companySlug, progress.roleSlug),
+      JSON.stringify(progress)
+    );
+  } catch {
+    // Ignore storage errors (quota exceeded, etc.)
+  }
+}
+
+/**
+ * Load carousel progress from Supabase journey_progress table
+ * Returns null if not authenticated or no saved progress
+ */
+async function loadFromSupabase(
+  companySlug: string,
+  roleSlug: string
+): Promise<CarouselProgress | null> {
+  try {
+    const supabase = createBrowserClient();
+
+    // Check if user is authenticated
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return null;
+
+    // Use journey_id format: carousel-{company}-{role}
+    const journeyId = `carousel-${companySlug}-${roleSlug}`;
+
+    const { data, error } = await supabase
+      .from("journey_progress")
+      .select("*")
+      .eq("user_id", user.id)
+      .eq("journey_id", journeyId)
+      .single();
+
+    if (error || !data) return null;
+
+    // Convert Supabase row to CarouselProgress
+    // The journey_progress table stores: current_step_index, completed_steps (array)
+    return {
+      companySlug,
+      roleSlug,
+      currentIndex: data.current_step_index,
+      completedItems: data.completed_steps || [],
+      lastUpdated: new Date(data.last_updated).getTime(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save carousel progress to Supabase journey_progress table
+ * No-op if user is not authenticated
+ */
+async function saveToSupabase(progress: CarouselProgress): Promise<boolean> {
+  try {
+    const supabase = createBrowserClient();
+
+    // Check if user is authenticated
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return false;
+
+    // Use journey_id format: carousel-{company}-{role}
+    const journeyId = `carousel-${progress.companySlug}-${progress.roleSlug}`;
+
+    const { error } = await supabase.from("journey_progress").upsert(
+      {
+        user_id: user.id,
+        journey_id: journeyId,
+        current_step_index: progress.currentIndex,
+        completed_steps: progress.completedItems,
+        answers: [], // Carousel doesn't use answers, but field may be required
+        last_updated: new Date(progress.lastUpdated).toISOString(),
+      },
+      {
+        onConflict: "user_id,journey_id",
+      }
+    );
+
+    return !error;
+  } catch {
+    return false;
+  }
+}
+
+interface CarouselProviderProps {
+  options: CarouselOptions;
+  children: ReactNode;
+  /** Enable Supabase sync for logged-in users (default: true) */
+  enableSupabaseSync?: boolean;
+}
+
+export function CarouselProvider({
+  options,
+  children,
+  enableSupabaseSync = true,
+}: CarouselProviderProps) {
+  const {
+    companySlug,
+    roleSlug,
+    items,
+    paywallIndex = null,
+    hasPremiumAccess = false,
+    initialIndex,
+    initialCompletedItems,
+  } = options;
+
+  // Track if Supabase state has been loaded
+  const supabaseLoadedRef = useRef(false);
+  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const lastSavedRef = useRef<string>("");
+
+  // Load persisted state or use defaults
+  const [currentIndex, setCurrentIndex] = useState(() => {
+    // If initialIndex is provided, use it
+    if (initialIndex !== undefined) return initialIndex;
+
+    // Otherwise try to load from localStorage
+    const persisted = loadPersistedProgress(companySlug, roleSlug);
+    if (persisted) return persisted.currentIndex;
+    return 0;
+  });
+
+  const [completedItems, setCompletedItems] = useState<Set<string>>(() => {
+    // If initialCompletedItems is provided, use it
+    if (initialCompletedItems) return new Set(initialCompletedItems);
+
+    // Otherwise try to load from localStorage
+    const persisted = loadPersistedProgress(companySlug, roleSlug);
+    if (persisted) return new Set(persisted.completedItems);
+    return new Set<string>();
+  });
+
+  const [isPaused, setIsPaused] = useState(false);
+  const [lastDirection, setLastDirection] = useState<CarouselDirection | null>(
+    null
+  );
+
+  // Persist state to localStorage whenever it changes
+  useEffect(() => {
+    const progress: CarouselProgress = {
+      companySlug,
+      roleSlug,
+      currentIndex,
+      completedItems: Array.from(completedItems),
+      lastUpdated: Date.now(),
+    };
+
+    persistProgress(progress);
+  }, [companySlug, roleSlug, currentIndex, completedItems]);
+
+  // Supabase sync: Load from Supabase on mount (once)
+  useEffect(() => {
+    if (!enableSupabaseSync || supabaseLoadedRef.current) return;
+    supabaseLoadedRef.current = true;
+
+    const localProgress = loadPersistedProgress(companySlug, roleSlug);
+    const localTimestamp = localProgress?.lastUpdated ?? 0;
+
+    loadFromSupabase(companySlug, roleSlug).then((remoteProgress) => {
+      if (remoteProgress && remoteProgress.lastUpdated > localTimestamp) {
+        // Remote state is newer, apply it
+        setCurrentIndex(remoteProgress.currentIndex);
+        setCompletedItems(new Set(remoteProgress.completedItems));
+      }
+    });
+  }, [companySlug, roleSlug, enableSupabaseSync]);
+
+  // Supabase sync: Save to Supabase on state changes (debounced 1 second)
+  useEffect(() => {
+    if (!enableSupabaseSync) return;
+
+    const stateKey = JSON.stringify({
+      currentIndex,
+      completedItems: Array.from(completedItems),
+    });
+
+    // Skip if state hasn't changed
+    if (stateKey === lastSavedRef.current) return;
+
+    // Clear previous timeout
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+
+    // Debounce save by 1 second
+    saveTimeoutRef.current = setTimeout(() => {
+      const progress: CarouselProgress = {
+        companySlug,
+        roleSlug,
+        currentIndex,
+        completedItems: Array.from(completedItems),
+        lastUpdated: Date.now(),
+      };
+
+      saveToSupabase(progress).then((success) => {
+        if (success) {
+          lastSavedRef.current = stateKey;
+        }
+      });
+    }, 1000);
+
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+    };
+  }, [companySlug, roleSlug, currentIndex, completedItems, enableSupabaseSync]);
+
+  // Derived values
+  const safeIndex = Math.max(0, Math.min(currentIndex, items.length - 1));
+  const currentItem = items.length > 0 ? (items[safeIndex] ?? null) : null;
+  const totalItems = items.length;
+  const completedCount = completedItems.size;
+  const progress =
+    totalItems > 0 ? Math.round((completedCount / totalItems) * 100) : 0;
+  const isFirstItem = safeIndex === 0;
+  const isLastItem = safeIndex === items.length - 1;
+
+  // Check if currently at paywall
+  const isAtPaywall = useMemo(() => {
+    if (paywallIndex === null) return false;
+    if (hasPremiumAccess) return false;
+    return safeIndex >= paywallIndex;
+  }, [paywallIndex, hasPremiumAccess, safeIndex]);
+
+  // Check if can navigate next
+  const canGoNext = useMemo(() => {
+    if (isLastItem) return false;
+    // If at paywall without premium access, can't go next
+    if (isAtPaywall) return false;
+    // If paywallIndex is set and next item would be at/after paywall without access
+    if (
+      paywallIndex !== null &&
+      !hasPremiumAccess &&
+      safeIndex + 1 >= paywallIndex
+    ) {
+      return false;
+    }
+    return true;
+  }, [isLastItem, isAtPaywall, paywallIndex, hasPremiumAccess, safeIndex]);
+
+  // Check if can navigate prev
+  const canGoPrev = useMemo(() => {
+    return !isFirstItem;
+  }, [isFirstItem]);
+
+  // Navigation actions
+  const next = useCallback(() => {
+    if (!canGoNext) return;
+    setLastDirection("next");
+    setCurrentIndex((prev) => Math.min(prev + 1, items.length - 1));
+  }, [canGoNext, items.length]);
+
+  const prev = useCallback(() => {
+    if (!canGoPrev) return;
+    setLastDirection("prev");
+    setCurrentIndex((prev) => Math.max(prev - 1, 0));
+  }, [canGoPrev]);
+
+  const goTo = useCallback(
+    (index: number) => {
+      if (index < 0 || index >= items.length) return;
+
+      // Check paywall restriction
+      if (paywallIndex !== null && !hasPremiumAccess && index >= paywallIndex) {
+        // Can't navigate to premium items without access
+        return;
+      }
+
+      // Set direction based on whether we're going forward or backward
+      setLastDirection(index > currentIndex ? "next" : "prev");
+      setCurrentIndex(index);
+    },
+    [items.length, paywallIndex, hasPremiumAccess, currentIndex]
+  );
+
+  const pause = useCallback(() => {
+    setIsPaused(true);
+  }, []);
+
+  const resume = useCallback(() => {
+    setIsPaused(false);
+  }, []);
+
+  const markComplete = useCallback((itemId: string) => {
+    setCompletedItems((prev) => {
+      const next = new Set(prev);
+      next.add(itemId);
+      return next;
+    });
+  }, []);
+
+  // Build state object
+  const state: CarouselState = useMemo(
+    () => ({
+      currentIndex: safeIndex,
+      items,
+      isPaused,
+      paywallIndex,
+      hasPremiumAccess,
+      completedItems,
+      lastDirection,
+    }),
+    [
+      safeIndex,
+      items,
+      isPaused,
+      paywallIndex,
+      hasPremiumAccess,
+      completedItems,
+      lastDirection,
+    ]
+  );
+
+  // Build context value
+  const value = useMemo<CarouselContextValue>(
+    () => ({
+      state,
+      currentItem,
+      progress,
+      totalItems,
+      completedCount,
+      isFirstItem,
+      isLastItem,
+      isAtPaywall,
+      companySlug,
+      roleSlug,
+      next,
+      prev,
+      goTo,
+      pause,
+      resume,
+      markComplete,
+      canGoNext,
+      canGoPrev,
+    }),
+    [
+      state,
+      currentItem,
+      progress,
+      totalItems,
+      completedCount,
+      isFirstItem,
+      isLastItem,
+      isAtPaywall,
+      companySlug,
+      roleSlug,
+      next,
+      prev,
+      goTo,
+      pause,
+      resume,
+      markComplete,
+      canGoNext,
+      canGoPrev,
+    ]
+  );
+
+  return (
+    <CarouselContext.Provider value={value}>
+      {children}
+    </CarouselContext.Provider>
+  );
+}
+
+/**
+ * Hook to access carousel state and actions
+ * Must be used within a CarouselProvider
+ */
+export function useCarousel(): CarouselContextValue {
+  const context = useContext(CarouselContext);
+  if (!context) {
+    throw new Error("useCarousel must be used within a CarouselProvider");
+  }
+  return context;
+}

--- a/src/components/carousel/__tests__/CarouselContext.test.tsx
+++ b/src/components/carousel/__tests__/CarouselContext.test.tsx
@@ -1,0 +1,848 @@
+import { render, screen, act } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
+import { CarouselProvider, useCarousel } from "../CarouselContext";
+import type { CarouselItem, CarouselOptions, ContentBlock } from "@/types";
+
+// Mock localStorage
+const mockLocalStorage = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: jest.fn((key: string) => store[key] ?? null),
+    setItem: jest.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: jest.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: jest.fn(() => {
+      store = {};
+    }),
+    get store() {
+      return store;
+    },
+  };
+})();
+
+Object.defineProperty(window, "localStorage", {
+  value: mockLocalStorage,
+});
+
+// Mock Supabase
+jest.mock("@/lib/supabase/client", () => ({
+  createBrowserClient: jest.fn(() => ({
+    auth: {
+      getUser: jest.fn().mockResolvedValue({ data: { user: null } }),
+    },
+    from: jest.fn(() => ({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: null, error: null }),
+      upsert: jest.fn().mockResolvedValue({ error: null }),
+    })),
+  })),
+}));
+
+// Test data factories
+function createContentBlock(
+  overrides: Partial<ContentBlock> = {}
+): ContentBlock {
+  return {
+    type: "text",
+    id: "block-1",
+    content: "Test content",
+    ...overrides,
+  } as ContentBlock;
+}
+
+function createCarouselItem(
+  overrides: Partial<CarouselItem> = {}
+): CarouselItem {
+  return {
+    id: "item-1",
+    type: "content",
+    content: createContentBlock(),
+    moduleSlug: "test-module",
+    isPremium: false,
+    order: 0,
+    ...overrides,
+  };
+}
+
+function createOptions(overrides: Partial<CarouselOptions> = {}): CarouselOptions {
+  return {
+    companySlug: "test-company",
+    roleSlug: "test-role",
+    items: [
+      createCarouselItem({ id: "item-1", order: 0 }),
+      createCarouselItem({ id: "item-2", order: 1 }),
+      createCarouselItem({ id: "item-3", order: 2 }),
+    ],
+    ...overrides,
+  };
+}
+
+// Wrapper component for testing hooks
+function createWrapper(options: CarouselOptions, enableSupabaseSync = true) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <CarouselProvider options={options} enableSupabaseSync={enableSupabaseSync}>
+        {children}
+      </CarouselProvider>
+    );
+  };
+}
+
+describe("CarouselProvider", () => {
+  beforeEach(() => {
+    mockLocalStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe("initialization", () => {
+    test("initializes at index 0", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.state.currentIndex).toBe(0);
+    });
+
+    test("initializes with initialIndex option", () => {
+      const options = createOptions({ initialIndex: 2 });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.state.currentIndex).toBe(2);
+    });
+
+    test("initializes with empty completedItems", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.state.completedItems.size).toBe(0);
+    });
+
+    test("initializes with initialCompletedItems option", () => {
+      const options = createOptions({
+        initialCompletedItems: ["item-1", "item-2"],
+      });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.state.completedItems.size).toBe(2);
+      expect(result.current.state.completedItems.has("item-1")).toBe(true);
+      expect(result.current.state.completedItems.has("item-2")).toBe(true);
+    });
+
+    test("provides currentItem", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.currentItem).toEqual(options.items[0]);
+    });
+
+    test("provides totalItems", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.totalItems).toBe(3);
+    });
+
+    test("provides companySlug and roleSlug", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.companySlug).toBe("test-company");
+      expect(result.current.roleSlug).toBe("test-role");
+    });
+  });
+
+  describe("next navigation", () => {
+    test("next increments currentIndex", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.state.currentIndex).toBe(0);
+
+      act(() => {
+        result.current.next();
+      });
+
+      expect(result.current.state.currentIndex).toBe(1);
+    });
+
+    test("next does not exceed last item", () => {
+      const options = createOptions({ initialIndex: 2 });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.state.currentIndex).toBe(2);
+      expect(result.current.isLastItem).toBe(true);
+
+      act(() => {
+        result.current.next();
+      });
+
+      expect(result.current.state.currentIndex).toBe(2); // Unchanged
+    });
+
+    test("next sets lastDirection to next", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      act(() => {
+        result.current.next();
+      });
+
+      expect(result.current.state.lastDirection).toBe("next");
+    });
+  });
+
+  describe("prev navigation", () => {
+    test("prev decrements currentIndex", () => {
+      const options = createOptions({ initialIndex: 2 });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.state.currentIndex).toBe(2);
+
+      act(() => {
+        result.current.prev();
+      });
+
+      expect(result.current.state.currentIndex).toBe(1);
+    });
+
+    test("prev does not go below 0", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.state.currentIndex).toBe(0);
+      expect(result.current.isFirstItem).toBe(true);
+
+      act(() => {
+        result.current.prev();
+      });
+
+      expect(result.current.state.currentIndex).toBe(0); // Unchanged
+    });
+
+    test("prev sets lastDirection to prev", () => {
+      const options = createOptions({ initialIndex: 2 });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      act(() => {
+        result.current.prev();
+      });
+
+      expect(result.current.state.lastDirection).toBe("prev");
+    });
+  });
+
+  describe("goTo navigation", () => {
+    test("goTo navigates to specific index", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      act(() => {
+        result.current.goTo(2);
+      });
+
+      expect(result.current.state.currentIndex).toBe(2);
+    });
+
+    test("goTo ignores invalid negative index", () => {
+      const options = createOptions({ initialIndex: 1 });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      act(() => {
+        result.current.goTo(-1);
+      });
+
+      expect(result.current.state.currentIndex).toBe(1); // Unchanged
+    });
+
+    test("goTo ignores index beyond items length", () => {
+      const options = createOptions({ initialIndex: 1 });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      act(() => {
+        result.current.goTo(10);
+      });
+
+      expect(result.current.state.currentIndex).toBe(1); // Unchanged
+    });
+
+    test("goTo sets correct lastDirection when going forward", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      act(() => {
+        result.current.goTo(2);
+      });
+
+      expect(result.current.state.lastDirection).toBe("next");
+    });
+
+    test("goTo sets correct lastDirection when going backward", () => {
+      const options = createOptions({ initialIndex: 2 });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      act(() => {
+        result.current.goTo(0);
+      });
+
+      expect(result.current.state.lastDirection).toBe("prev");
+    });
+  });
+
+  describe("markComplete", () => {
+    test("markComplete adds item to completedItems", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.state.completedItems.has("item-1")).toBe(false);
+
+      act(() => {
+        result.current.markComplete("item-1");
+      });
+
+      expect(result.current.state.completedItems.has("item-1")).toBe(true);
+    });
+
+    test("markComplete updates completedCount", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.completedCount).toBe(0);
+
+      act(() => {
+        result.current.markComplete("item-1");
+        result.current.markComplete("item-2");
+      });
+
+      expect(result.current.completedCount).toBe(2);
+    });
+
+    test("markComplete is idempotent", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      act(() => {
+        result.current.markComplete("item-1");
+        result.current.markComplete("item-1");
+        result.current.markComplete("item-1");
+      });
+
+      expect(result.current.state.completedItems.size).toBe(1);
+    });
+  });
+
+  describe("pause and resume", () => {
+    test("pause sets isPaused to true", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.state.isPaused).toBe(false);
+
+      act(() => {
+        result.current.pause();
+      });
+
+      expect(result.current.state.isPaused).toBe(true);
+    });
+
+    test("resume sets isPaused to false", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      act(() => {
+        result.current.pause();
+      });
+
+      expect(result.current.state.isPaused).toBe(true);
+
+      act(() => {
+        result.current.resume();
+      });
+
+      expect(result.current.state.isPaused).toBe(false);
+    });
+  });
+
+  describe("progress", () => {
+    test("progress returns correct percentage", () => {
+      const options = createOptions(); // 3 items
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.progress).toBe(0);
+
+      act(() => {
+        result.current.markComplete("item-1");
+      });
+
+      expect(result.current.progress).toBe(33); // 1/3 ≈ 33%
+
+      act(() => {
+        result.current.markComplete("item-2");
+      });
+
+      expect(result.current.progress).toBe(67); // 2/3 ≈ 67%
+
+      act(() => {
+        result.current.markComplete("item-3");
+      });
+
+      expect(result.current.progress).toBe(100); // 3/3 = 100%
+    });
+
+    test("progress handles empty items", () => {
+      const options = createOptions({ items: [] });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.progress).toBe(0);
+    });
+  });
+
+  describe("canGoNext and canGoPrev", () => {
+    test("canGoNext true when not at last item", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.canGoNext).toBe(true);
+    });
+
+    test("canGoNext false when at last item", () => {
+      const options = createOptions({ initialIndex: 2 });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.isLastItem).toBe(true);
+      expect(result.current.canGoNext).toBe(false);
+    });
+
+    test("canGoPrev false when at first item", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.isFirstItem).toBe(true);
+      expect(result.current.canGoPrev).toBe(false);
+    });
+
+    test("canGoPrev true when not at first item", () => {
+      const options = createOptions({ initialIndex: 1 });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.canGoPrev).toBe(true);
+    });
+  });
+
+  describe("paywall behavior", () => {
+    test("isAtPaywall false when no paywall", () => {
+      const options = createOptions({ paywallIndex: null });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.isAtPaywall).toBe(false);
+    });
+
+    test("isAtPaywall false when before paywall", () => {
+      const options = createOptions({ paywallIndex: 2, initialIndex: 0 });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.isAtPaywall).toBe(false);
+    });
+
+    test("isAtPaywall true when at paywall without access", () => {
+      const options = createOptions({
+        paywallIndex: 1,
+        initialIndex: 1,
+        hasPremiumAccess: false,
+      });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.isAtPaywall).toBe(true);
+    });
+
+    test("isAtPaywall false when at paywall with premium access", () => {
+      const options = createOptions({
+        paywallIndex: 1,
+        initialIndex: 1,
+        hasPremiumAccess: true,
+      });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.isAtPaywall).toBe(false);
+    });
+
+    test("canGoNext false when next would hit paywall without access", () => {
+      const options = createOptions({
+        paywallIndex: 1,
+        initialIndex: 0,
+        hasPremiumAccess: false,
+      });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.canGoNext).toBe(false);
+    });
+
+    test("canGoNext true when has premium access past paywall", () => {
+      const options = createOptions({
+        paywallIndex: 1,
+        initialIndex: 0,
+        hasPremiumAccess: true,
+      });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.canGoNext).toBe(true);
+    });
+
+    test("goTo blocked by paywall without access", () => {
+      const options = createOptions({
+        paywallIndex: 1,
+        initialIndex: 0,
+        hasPremiumAccess: false,
+      });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      act(() => {
+        result.current.goTo(2); // Try to go past paywall
+      });
+
+      expect(result.current.state.currentIndex).toBe(0); // Unchanged
+    });
+
+    test("goTo allowed past paywall with access", () => {
+      const options = createOptions({
+        paywallIndex: 1,
+        initialIndex: 0,
+        hasPremiumAccess: true,
+      });
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      act(() => {
+        result.current.goTo(2);
+      });
+
+      expect(result.current.state.currentIndex).toBe(2);
+    });
+  });
+
+  describe("localStorage persistence", () => {
+    test("persists to localStorage on index change", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      act(() => {
+        result.current.next();
+      });
+
+      expect(mockLocalStorage.setItem).toHaveBeenCalled();
+      const storedKey = "carousel-test-company-test-role";
+      const stored = JSON.parse(mockLocalStorage.store[storedKey]!);
+      expect(stored.currentIndex).toBe(1);
+    });
+
+    test("persists completedItems to localStorage", () => {
+      const options = createOptions();
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      act(() => {
+        result.current.markComplete("item-1");
+      });
+
+      const storedKey = "carousel-test-company-test-role";
+      const stored = JSON.parse(mockLocalStorage.store[storedKey]!);
+      expect(stored.completedItems).toContain("item-1");
+    });
+
+    test("loads persisted state on mount", () => {
+      const options = createOptions();
+      const storedProgress = {
+        companySlug: "test-company",
+        roleSlug: "test-role",
+        currentIndex: 2,
+        completedItems: ["item-1", "item-2"],
+        lastUpdated: Date.now(),
+      };
+      mockLocalStorage.store["carousel-test-company-test-role"] =
+        JSON.stringify(storedProgress);
+
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      expect(result.current.state.currentIndex).toBe(2);
+      expect(result.current.state.completedItems.has("item-1")).toBe(true);
+      expect(result.current.state.completedItems.has("item-2")).toBe(true);
+    });
+
+    test("handles invalid localStorage data gracefully", () => {
+      const options = createOptions();
+      mockLocalStorage.store["carousel-test-company-test-role"] = "invalid-json";
+
+      const { result } = renderHook(() => useCarousel(), {
+        wrapper: createWrapper(options),
+      });
+
+      // Should fall back to defaults
+      expect(result.current.state.currentIndex).toBe(0);
+      expect(result.current.state.completedItems.size).toBe(0);
+    });
+  });
+
+  describe("useCarousel outside provider", () => {
+    test("throws error when used outside provider", () => {
+      // Suppress console.error for this test
+      const consoleSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useCarousel());
+      }).toThrow("useCarousel must be used within a CarouselProvider");
+
+      consoleSpy.mockRestore();
+    });
+  });
+});
+
+describe("CarouselProvider rendering", () => {
+  beforeEach(() => {
+    mockLocalStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  test("renders children", () => {
+    const options = createOptions();
+    render(
+      <CarouselProvider options={options}>
+        <div data-testid="child">Child content</div>
+      </CarouselProvider>
+    );
+
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+    expect(screen.getByText("Child content")).toBeInTheDocument();
+  });
+
+  test("provides context to nested components", () => {
+    const options = createOptions();
+
+    function NestedComponent() {
+      const { state, totalItems, companySlug } = useCarousel();
+      return (
+        <div data-testid="nested">
+          Item {state.currentIndex + 1} of {totalItems} ({companySlug})
+        </div>
+      );
+    }
+
+    render(
+      <CarouselProvider options={options}>
+        <NestedComponent />
+      </CarouselProvider>
+    );
+
+    expect(screen.getByTestId("nested")).toHaveTextContent(
+      "Item 1 of 3 (test-company)"
+    );
+  });
+});
+
+describe("Supabase sync integration", () => {
+  beforeEach(() => {
+    mockLocalStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  test("enableSupabaseSync defaults to true", () => {
+    const options = createOptions();
+    const { result } = renderHook(() => useCarousel(), {
+      wrapper: createWrapper(options),
+    });
+
+    // Just verify the hook works with default settings
+    expect(result.current.state.currentIndex).toBe(0);
+  });
+
+  test("works with enableSupabaseSync=false", () => {
+    const options = createOptions();
+
+    function WrapperWithSyncDisabled({
+      children,
+    }: {
+      children: React.ReactNode;
+    }) {
+      return (
+        <CarouselProvider options={options} enableSupabaseSync={false}>
+          {children}
+        </CarouselProvider>
+      );
+    }
+
+    const { result } = renderHook(() => useCarousel(), {
+      wrapper: WrapperWithSyncDisabled,
+    });
+
+    expect(result.current.state.currentIndex).toBe(0);
+
+    act(() => {
+      result.current.next();
+    });
+
+    expect(result.current.state.currentIndex).toBe(1);
+  });
+
+  test("state changes are persisted to localStorage even with Supabase sync enabled", () => {
+    const options = createOptions();
+    const { result } = renderHook(() => useCarousel(), {
+      wrapper: createWrapper(options),
+    });
+
+    act(() => {
+      result.current.markComplete("item-1");
+    });
+
+    // Check localStorage was called
+    expect(mockLocalStorage.setItem).toHaveBeenCalled();
+  });
+});
+
+describe("isFirstItem and isLastItem", () => {
+  beforeEach(() => {
+    mockLocalStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  test("isFirstItem true at index 0", () => {
+    const options = createOptions();
+    const { result } = renderHook(() => useCarousel(), {
+      wrapper: createWrapper(options),
+    });
+
+    expect(result.current.isFirstItem).toBe(true);
+  });
+
+  test("isFirstItem false when not at index 0", () => {
+    const options = createOptions({ initialIndex: 1 });
+    const { result } = renderHook(() => useCarousel(), {
+      wrapper: createWrapper(options),
+    });
+
+    expect(result.current.isFirstItem).toBe(false);
+  });
+
+  test("isLastItem true at last index", () => {
+    const options = createOptions({ initialIndex: 2 });
+    const { result } = renderHook(() => useCarousel(), {
+      wrapper: createWrapper(options),
+    });
+
+    expect(result.current.isLastItem).toBe(true);
+  });
+
+  test("isLastItem false when not at last index", () => {
+    const options = createOptions();
+    const { result } = renderHook(() => useCarousel(), {
+      wrapper: createWrapper(options),
+    });
+
+    expect(result.current.isLastItem).toBe(false);
+  });
+});
+
+describe("empty items handling", () => {
+  beforeEach(() => {
+    mockLocalStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  test("currentItem is null with empty items", () => {
+    const options = createOptions({ items: [] });
+    const { result } = renderHook(() => useCarousel(), {
+      wrapper: createWrapper(options),
+    });
+
+    expect(result.current.currentItem).toBeNull();
+  });
+
+  test("totalItems is 0 with empty items", () => {
+    const options = createOptions({ items: [] });
+    const { result } = renderHook(() => useCarousel(), {
+      wrapper: createWrapper(options),
+    });
+
+    expect(result.current.totalItems).toBe(0);
+  });
+});

--- a/src/components/carousel/index.ts
+++ b/src/components/carousel/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Carousel components for JobWiz
+ * Swipeable carousel UI for content navigation
+ */
+
+export { CarouselProvider, useCarousel } from "./CarouselContext";


### PR DESCRIPTION
## Summary
- Create CarouselProvider component with full state management for carousel UI
- Implement navigation methods: next(), prev(), goTo(), pause(), resume(), markComplete()
- Add localStorage persistence with key `carousel-{companySlug}-{roleSlug}`
- Add Supabase sync to journey_progress table (debounced 1 second)
- Support paywall restrictions via canGoNext/canGoPrev based on paywallIndex
- Create useCarousel() hook for consuming context

## Test plan
- [x] Run `npm run lint` - no errors
- [x] Run `npm run type-check` - no errors
- [x] Run `npm run build` - successful
- [x] Run carousel tests (53 tests pass)
- [x] Verify navigation methods work correctly
- [x] Verify localStorage persistence on state change
- [x] Verify paywall restrictions are enforced

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)