### PR TITLE
Add carousel module loader for company/role pairs (#131)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -2579,3 +2579,46 @@ All Stage 5 (Launch) code issues are now closed:
   - Shows value prop and purchase CTA ✓
   - On purchase, auto-advances to next item ✓
   - Skip if user already purchased ✓
+
+### 2026-01-18 - Issue #131: B6: Module loader for carousel
+
+**Completed:**
+- Created `/src/lib/carousel/load-modules.ts` with module loading functionality
+- Implemented `loadCarouselModules(company, role)` that returns ordered modules
+- Module order: universal → company → role → company-role (industry skipped per spec)
+- Returns `{ freeModules, premiumModules, allModules }` split at paywall boundary
+- Free modules = universal only, Premium modules = company + role + company-role
+- Created helper functions: `hasCompanyRoleModule()`, `getModuleOrderIndex()`
+- Created `/src/lib/carousel/index.ts` for exports
+
+**Features:**
+- Loads modules from `/data/generated/modules/` directory
+- Parses JSON module files and maps to Module interface
+- Handles missing modules gracefully (returns empty arrays)
+- Correctly filters out industry modules
+- Sorts universal modules by display_order
+
+**Files Created:**
+- `src/lib/carousel/load-modules.ts`
+- `src/lib/carousel/index.ts`
+- `src/lib/carousel/__tests__/load-modules.test.ts`
+
+**Tests:**
+- 23 unit tests covering:
+  - Module ordering for google/software-engineer
+  - Module ordering for amazon/product-manager
+  - Free/premium module split
+  - Non-existent company/role handling
+  - Module structure validation
+  - hasCompanyRoleModule utility
+  - getModuleOrderIndex utility
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - 23 new carousel loader tests pass (2081 total passed, 12 pre-existing failures unrelated to this change)
+- All acceptance criteria verified:
+  - Returns correct modules in correct order for google/software-engineer ✓
+  - Order: universal → company → role → company-role ✓
+  - Returns { freeModules, premiumModules } split at paywall ✓

--- a/src/lib/carousel/__tests__/load-modules.test.ts
+++ b/src/lib/carousel/__tests__/load-modules.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for carousel module loader
+ */
+
+import {
+  loadCarouselModules,
+  hasCompanyRoleModule,
+  getModuleOrderIndex,
+} from "../load-modules";
+
+describe("loadCarouselModules", () => {
+  describe("for google/software-engineer", () => {
+    it("returns modules in correct order: universal → company → role → company-role", () => {
+      const result = loadCarouselModules("google", "software-engineer");
+
+      expect(result.allModules.length).toBeGreaterThan(0);
+
+      // Check module types are in order
+      const types = result.allModules.map((m) => m.type);
+      const typeOrder = ["universal", "company", "role", "company-role"];
+
+      let lastIndex = -1;
+      for (const type of types) {
+        const currentIndex = typeOrder.indexOf(type);
+        expect(currentIndex).toBeGreaterThanOrEqual(lastIndex);
+        lastIndex = currentIndex;
+      }
+    });
+
+    it("returns universal modules as freeModules", () => {
+      const result = loadCarouselModules("google", "software-engineer");
+
+      expect(result.freeModules.length).toBeGreaterThan(0);
+      for (const mod of result.freeModules) {
+        expect(mod.type).toBe("universal");
+      }
+    });
+
+    it("returns company, role, and company-role modules as premiumModules", () => {
+      const result = loadCarouselModules("google", "software-engineer");
+
+      expect(result.premiumModules.length).toBeGreaterThan(0);
+      for (const mod of result.premiumModules) {
+        expect(["company", "role", "company-role"]).toContain(mod.type);
+      }
+    });
+
+    it("includes google company module", () => {
+      const result = loadCarouselModules("google", "software-engineer");
+
+      const companyModule = result.allModules.find(
+        (m) => m.type === "company" && m.companySlug === "google"
+      );
+      expect(companyModule).toBeDefined();
+      expect(companyModule?.slug).toBe("company-google");
+    });
+
+    it("includes software-engineer role module", () => {
+      const result = loadCarouselModules("google", "software-engineer");
+
+      const roleModule = result.allModules.find(
+        (m) => m.type === "role" && m.roleSlug === "software-engineer"
+      );
+      expect(roleModule).toBeDefined();
+      expect(roleModule?.slug).toBe("role-software-engineer");
+    });
+
+    it("includes google-software-engineer company-role module", () => {
+      const result = loadCarouselModules("google", "software-engineer");
+
+      const companyRoleModule = result.allModules.find(
+        (m) =>
+          m.type === "company-role" &&
+          m.companySlug === "google" &&
+          m.roleSlug === "software-engineer"
+      );
+      expect(companyRoleModule).toBeDefined();
+      expect(companyRoleModule?.slug).toBe(
+        "company-role-google-software-engineer"
+      );
+    });
+
+    it("does not include industry modules", () => {
+      const result = loadCarouselModules("google", "software-engineer");
+
+      const industryModules = result.allModules.filter(
+        (m) => m.type === "industry"
+      );
+      expect(industryModules.length).toBe(0);
+    });
+
+    it("splits modules correctly at paywall", () => {
+      const result = loadCarouselModules("google", "software-engineer");
+
+      // Free modules should only be universal
+      const freeTypes = new Set(result.freeModules.map((m) => m.type));
+      expect(freeTypes.size).toBe(1);
+      expect(freeTypes.has("universal")).toBe(true);
+
+      // Premium modules should not include universal
+      const premiumTypes = new Set(result.premiumModules.map((m) => m.type));
+      expect(premiumTypes.has("universal")).toBe(false);
+    });
+
+    it("allModules equals freeModules + premiumModules", () => {
+      const result = loadCarouselModules("google", "software-engineer");
+
+      const combined = [...result.freeModules, ...result.premiumModules];
+      expect(combined.length).toBe(result.allModules.length);
+
+      // Same slugs in same order
+      expect(combined.map((m) => m.slug)).toEqual(
+        result.allModules.map((m) => m.slug)
+      );
+    });
+  });
+
+  describe("for amazon/product-manager", () => {
+    it("returns correct modules for different company/role", () => {
+      const result = loadCarouselModules("amazon", "product-manager");
+
+      expect(result.allModules.length).toBeGreaterThan(0);
+
+      const companyModule = result.allModules.find(
+        (m) => m.type === "company" && m.companySlug === "amazon"
+      );
+      expect(companyModule).toBeDefined();
+
+      const roleModule = result.allModules.find(
+        (m) => m.type === "role" && m.roleSlug === "product-manager"
+      );
+      expect(roleModule).toBeDefined();
+    });
+  });
+
+  describe("for non-existent company/role", () => {
+    it("returns universal modules even when company does not exist", () => {
+      const result = loadCarouselModules(
+        "nonexistent-company",
+        "software-engineer"
+      );
+
+      expect(result.freeModules.length).toBeGreaterThan(0);
+      expect(result.freeModules.every((m) => m.type === "universal")).toBe(
+        true
+      );
+    });
+
+    it("returns empty premium modules when company-role does not exist", () => {
+      const result = loadCarouselModules(
+        "nonexistent-company",
+        "nonexistent-role"
+      );
+
+      // Should have no company, role, or company-role modules
+      expect(
+        result.premiumModules.filter((m) => m.type === "company").length
+      ).toBe(0);
+      expect(
+        result.premiumModules.filter((m) => m.type === "role").length
+      ).toBe(0);
+      expect(
+        result.premiumModules.filter((m) => m.type === "company-role").length
+      ).toBe(0);
+    });
+  });
+
+  describe("module structure", () => {
+    it("modules have required fields", () => {
+      const result = loadCarouselModules("google", "software-engineer");
+
+      for (const mod of result.allModules) {
+        expect(mod.id).toBeDefined();
+        expect(mod.slug).toBeDefined();
+        expect(mod.type).toBeDefined();
+        expect(mod.title).toBeDefined();
+        expect(mod.sections).toBeDefined();
+        expect(Array.isArray(mod.sections)).toBe(true);
+        expect(typeof mod.isPremium).toBe("boolean");
+        expect(typeof mod.order).toBe("number");
+      }
+    });
+
+    it("universal modules are not premium", () => {
+      const result = loadCarouselModules("google", "software-engineer");
+
+      for (const mod of result.freeModules) {
+        expect(mod.isPremium).toBe(false);
+      }
+    });
+
+    it("premium modules have isPremium true", () => {
+      const result = loadCarouselModules("google", "software-engineer");
+
+      for (const mod of result.premiumModules) {
+        expect(mod.isPremium).toBe(true);
+      }
+    });
+  });
+});
+
+describe("hasCompanyRoleModule", () => {
+  it("returns true for existing company-role", () => {
+    expect(hasCompanyRoleModule("google", "software-engineer")).toBe(true);
+  });
+
+  it("returns false for non-existent company-role", () => {
+    expect(
+      hasCompanyRoleModule("nonexistent-company", "nonexistent-role")
+    ).toBe(false);
+  });
+
+  it("returns false for partial match", () => {
+    // Google exists, but not with this role
+    expect(hasCompanyRoleModule("google", "nonexistent-role")).toBe(false);
+  });
+});
+
+describe("getModuleOrderIndex", () => {
+  it("returns correct order for universal", () => {
+    expect(getModuleOrderIndex("universal")).toBe(0);
+  });
+
+  it("returns correct order for company", () => {
+    expect(getModuleOrderIndex("company")).toBe(1);
+  });
+
+  it("returns correct order for role", () => {
+    expect(getModuleOrderIndex("role")).toBe(2);
+  });
+
+  it("returns correct order for company-role", () => {
+    expect(getModuleOrderIndex("company-role")).toBe(3);
+  });
+
+  it("returns high index for industry (skipped type)", () => {
+    expect(getModuleOrderIndex("industry")).toBe(4);
+  });
+});

--- a/src/lib/carousel/index.ts
+++ b/src/lib/carousel/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Carousel library exports
+ */
+
+export {
+  loadCarouselModules,
+  hasCompanyRoleModule,
+  getModuleOrderIndex,
+  type CarouselModulesResult,
+} from "./load-modules";

--- a/src/lib/carousel/load-modules.ts
+++ b/src/lib/carousel/load-modules.ts
@@ -1,0 +1,226 @@
+/**
+ * Module loader for carousel
+ * Loads and orders modules for a company/role pair
+ */
+
+import { Module, ModuleType } from "@/types/module";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Result of loading carousel modules
+ */
+export interface CarouselModulesResult {
+  /** Free modules (universal) - before paywall */
+  freeModules: Module[];
+  /** Premium modules (company, role, company-role) - after paywall */
+  premiumModules: Module[];
+  /** All modules in order */
+  allModules: Module[];
+}
+
+/**
+ * Module order priority for carousel
+ * Industry modules are skipped per Stage 8 spec
+ */
+const MODULE_ORDER: ModuleType[] = [
+  "universal",
+  "company",
+  "role",
+  "company-role",
+];
+
+/**
+ * Get the modules directory path
+ */
+function getModulesDir(): string {
+  return path.join(process.cwd(), "data", "generated", "modules");
+}
+
+/**
+ * Parse a JSON module file and convert to Module interface
+ */
+function parseModuleFile(filePath: string): Module | null {
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    const data = JSON.parse(content) as Record<string, unknown>;
+
+    // Map JSON fields to Module interface
+    return {
+      id: (data.slug as string) || "",
+      slug: (data.slug as string) || "",
+      type: (data.type as ModuleType) || "universal",
+      title: (data.title as string) || "",
+      description: data.description as string | undefined,
+      sections: (data.sections as Module["sections"]) || [],
+      isPremium: (data.is_premium as boolean) || false,
+      order: (data.display_order as number) || 0,
+      industry: data.industry as string | undefined,
+      roleCategory: data.role_category as string | undefined,
+      companySlug: data.company_slug as string | undefined,
+      roleSlug: data.role_slug as string | undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load all universal modules
+ */
+function loadUniversalModules(modulesDir: string): Module[] {
+  const modules: Module[] = [];
+  const files = fs.readdirSync(modulesDir);
+
+  for (const file of files) {
+    if (file.startsWith("universal-") && file.endsWith(".json")) {
+      const parsedMod = parseModuleFile(path.join(modulesDir, file));
+      if (parsedMod && parsedMod.type === "universal") {
+        modules.push(parsedMod);
+      }
+    }
+  }
+
+  return modules.sort((a, b) => a.order - b.order);
+}
+
+/**
+ * Load company module for a specific company
+ */
+function loadCompanyModule(
+  modulesDir: string,
+  companySlug: string
+): Module | null {
+  const fileName = `company-${companySlug}.json`;
+  const filePath = path.join(modulesDir, fileName);
+
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  const parsedMod = parseModuleFile(filePath);
+  if (parsedMod && parsedMod.type === "company" && parsedMod.companySlug === companySlug) {
+    return parsedMod;
+  }
+
+  return null;
+}
+
+/**
+ * Load role module for a specific role
+ */
+function loadRoleModule(modulesDir: string, roleSlug: string): Module | null {
+  const fileName = `role-${roleSlug}.json`;
+  const filePath = path.join(modulesDir, fileName);
+
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  const parsedMod = parseModuleFile(filePath);
+  if (parsedMod && parsedMod.type === "role" && parsedMod.roleSlug === roleSlug) {
+    return parsedMod;
+  }
+
+  return null;
+}
+
+/**
+ * Load company-role module for a specific company/role pair
+ */
+function loadCompanyRoleModule(
+  modulesDir: string,
+  companySlug: string,
+  roleSlug: string
+): Module | null {
+  const fileName = `company-role-${companySlug}-${roleSlug}.json`;
+  const filePath = path.join(modulesDir, fileName);
+
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  const parsedMod = parseModuleFile(filePath);
+  if (
+    parsedMod &&
+    parsedMod.type === "company-role" &&
+    parsedMod.companySlug === companySlug &&
+    parsedMod.roleSlug === roleSlug
+  ) {
+    return parsedMod;
+  }
+
+  return null;
+}
+
+/**
+ * Load and order modules for a company/role pair
+ *
+ * @param companySlug - Company slug (e.g., "google")
+ * @param roleSlug - Role slug (e.g., "software-engineer")
+ * @returns Object with freeModules (universal) and premiumModules (company, role, company-role)
+ */
+export function loadCarouselModules(
+  companySlug: string,
+  roleSlug: string
+): CarouselModulesResult {
+  const modulesDir = getModulesDir();
+  const allModules: Module[] = [];
+
+  // 1. Load universal modules (FREE)
+  const universalModules = loadUniversalModules(modulesDir);
+  allModules.push(...universalModules);
+
+  // 2. Load company module (PREMIUM)
+  const companyModule = loadCompanyModule(modulesDir, companySlug);
+  if (companyModule) {
+    allModules.push(companyModule);
+  }
+
+  // 3. Load role module (PREMIUM)
+  const roleModule = loadRoleModule(modulesDir, roleSlug);
+  if (roleModule) {
+    allModules.push(roleModule);
+  }
+
+  // 4. Load company-role module (PREMIUM)
+  const companyRoleModule = loadCompanyRoleModule(
+    modulesDir,
+    companySlug,
+    roleSlug
+  );
+  if (companyRoleModule) {
+    allModules.push(companyRoleModule);
+  }
+
+  // Split into free (universal) and premium (everything else)
+  const freeModules = allModules.filter((m) => m.type === "universal");
+  const premiumModules = allModules.filter((m) => m.type !== "universal");
+
+  return {
+    freeModules,
+    premiumModules,
+    allModules,
+  };
+}
+
+/**
+ * Check if a module file exists for a company/role pair
+ */
+export function hasCompanyRoleModule(
+  companySlug: string,
+  roleSlug: string
+): boolean {
+  const modulesDir = getModulesDir();
+  const fileName = `company-role-${companySlug}-${roleSlug}.json`;
+  const filePath = path.join(modulesDir, fileName);
+  return fs.existsSync(filePath);
+}
+
+/**
+ * Get module order index for sorting
+ */
+export function getModuleOrderIndex(type: ModuleType): number {
+  const index = MODULE_ORDER.indexOf(type);
+  return index === -1 ? MODULE_ORDER.length : index;
+}


### PR DESCRIPTION
## Summary
- Create `loadCarouselModules(company, role)` that returns ordered modules
- Module order: universal → company → role → company-role (industry modules skipped per spec)
- Return `{ freeModules, premiumModules, allModules }` split at paywall boundary
- Free modules = universal only, Premium modules = company + role + company-role
- Add `hasCompanyRoleModule()` and `getModuleOrderIndex()` helper functions

## Test plan
- [x] Unit tests for module ordering (google/software-engineer, amazon/product-manager)
- [x] Unit tests for free/premium split
- [x] Unit tests for non-existent company/role handling
- [x] Unit tests for module structure validation
- [x] 23 tests passing
- [x] Lint passing
- [x] Type check passing
- [x] Build successful

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)