### PR TITLE
B7: Flatten modules to items (#132)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -2622,3 +2622,58 @@ All Stage 5 (Launch) code issues are now closed:
   - Returns correct modules in correct order for google/software-engineer ✓
   - Order: universal → company → role → company-role ✓
   - Returns { freeModules, premiumModules } split at paywall ✓
+
+### 2026-01-18 - Issue #132: B7: Flatten modules to items
+
+**Completed:**
+- Created `/src/lib/carousel/flatten-modules.ts` with module flattening functionality
+- Implemented `flattenToCarouselItems(freeModules, premiumModules)` that converts modules to flat CarouselItem array
+- Each content block becomes one CarouselItem with proper type mapping:
+  - Quiz blocks → `quiz` carousel type
+  - Checklist blocks → `checklist` carousel type
+  - All other blocks → `content` carousel type
+- Module title item inserted at start of each module (header block with level 1)
+- Paywall item inserted between free and premium modules (only if premium modules exist)
+- Created helper functions: `getModuleBlockCount()`, `getModuleItemCount()`
+- Content normalization handles both flat and nested content formats (from JSON modules)
+- Updated `/src/lib/carousel/index.ts` to export new functions
+
+**Features:**
+- Preserves section titles on each item for progress display
+- Unique IDs for all items: `{moduleSlug}-{blockId}`
+- Order field for each item (0-indexed)
+- isPremium flag derived from parent module
+- Handles edge cases: empty modules, empty sections, blocks without ID
+
+**Files Created:**
+- `src/lib/carousel/flatten-modules.ts`
+- `src/lib/carousel/__tests__/flatten-modules.test.ts`
+
+**Files Modified:**
+- `src/lib/carousel/index.ts` - Added new exports
+
+**Tests:**
+- 29 unit tests covering:
+  - Basic flattening (4 tests)
+  - Block type mapping (3 tests)
+  - Paywall insertion (3 tests)
+  - Premium content handling (2 tests)
+  - Multiple modules (1 test)
+  - Acceptance criteria: 3 modules with 10 blocks each → ~33 items (1 test)
+  - Content normalization (4 tests)
+  - Edge cases (6 tests)
+  - Unique item IDs (1 test)
+  - getModuleBlockCount (2 tests)
+  - getModuleItemCount (2 tests)
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - 29 new flatten-modules tests pass (2110 total passed, 12 pre-existing failures unrelated to this change)
+- All acceptance criteria verified:
+  - `flattenToCarouselItems(modules)` - sections → items ✓
+  - Each block becomes one CarouselItem ✓
+  - Insert module title item at start of each module ✓
+  - Insert paywall item between free and premium ✓
+  - Test: 3 modules with 10 blocks each → ~33 items (34 = 33 items + 1 paywall) ✓

--- a/src/lib/carousel/__tests__/flatten-modules.test.ts
+++ b/src/lib/carousel/__tests__/flatten-modules.test.ts
@@ -1,0 +1,866 @@
+/**
+ * Tests for flatten-modules.ts
+ */
+
+import {
+  flattenToCarouselItems,
+  getModuleBlockCount,
+  getModuleItemCount,
+  type FlattenResult,
+} from "../flatten-modules";
+import type { Module, ModuleSection, ContentBlock } from "@/types/module";
+
+// Helper to create a test module
+function createTestModule(
+  slug: string,
+  title: string,
+  type: "universal" | "company" | "role" | "company-role",
+  isPremium: boolean,
+  sections: ModuleSection[]
+): Module {
+  return {
+    id: slug,
+    slug,
+    type,
+    title,
+    description: `Test description for ${title}`,
+    sections,
+    isPremium,
+    order: 0,
+  };
+}
+
+// Helper to create a test section
+function createTestSection(
+  id: string,
+  title: string,
+  blocks: ContentBlock[]
+): ModuleSection {
+  return { id, title, blocks };
+}
+
+// Helper to create a text block
+function createTextBlock(id: string, text: string): ContentBlock {
+  return {
+    id,
+    type: "text",
+    content: text,
+  } as ContentBlock;
+}
+
+// Helper to create a quiz block
+function createQuizBlock(id: string, question: string): ContentBlock {
+  return {
+    id,
+    type: "quiz",
+    question,
+    options: [
+      { id: "a", text: "Option A", isCorrect: true },
+      { id: "b", text: "Option B", isCorrect: false },
+    ],
+    explanation: "Test explanation",
+  } as ContentBlock;
+}
+
+// Helper to create a checklist block
+function createChecklistBlock(id: string, title: string): ContentBlock {
+  return {
+    id,
+    type: "checklist",
+    title,
+    items: [
+      { id: "item1", text: "Item 1", required: true },
+      { id: "item2", text: "Item 2", required: false },
+    ],
+  } as ContentBlock;
+}
+
+// Helper to create a tip block
+function createTipBlock(id: string, text: string): ContentBlock {
+  return {
+    id,
+    type: "tip",
+    content: text,
+  } as ContentBlock;
+}
+
+// Helper to create a warning block
+function createWarningBlock(id: string, text: string): ContentBlock {
+  return {
+    id,
+    type: "warning",
+    content: text,
+  } as ContentBlock;
+}
+
+describe("flattenToCarouselItems", () => {
+  describe("basic flattening", () => {
+    it("should flatten a single free module", () => {
+      const testMod = createTestModule(
+        "universal-test",
+        "Test Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Text content 1"),
+            createTextBlock("block2", "Text content 2"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([testMod], []);
+
+      expect(result.items).toHaveLength(3); // 1 title + 2 blocks
+      expect(result.paywallIndex).toBeNull();
+      expect(result.totalItems).toBe(3);
+    });
+
+    it("should add module title at start of each module", () => {
+      const testMod = createTestModule(
+        "universal-test",
+        "Test Module Title",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Text content"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([testMod], []);
+
+      expect(result.items[0]).toMatchObject({
+        id: "universal-test-title",
+        type: "content",
+        moduleSlug: "universal-test",
+        isPremium: false,
+        sectionTitle: "Test Module Title",
+        order: 0,
+      });
+      expect(result.items[0]?.content.type).toBe("header");
+    });
+
+    it("should set correct order for each item", () => {
+      const testMod = createTestModule(
+        "universal-test",
+        "Test Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Text 1"),
+            createTextBlock("block2", "Text 2"),
+            createTextBlock("block3", "Text 3"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([testMod], []);
+
+      expect(result.items[0]?.order).toBe(0);
+      expect(result.items[1]?.order).toBe(1);
+      expect(result.items[2]?.order).toBe(2);
+      expect(result.items[3]?.order).toBe(3);
+    });
+
+    it("should preserve section title on each item", () => {
+      const testMod = createTestModule(
+        "universal-test",
+        "Test Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "First Section", [
+            createTextBlock("block1", "Text 1"),
+          ]),
+          createTestSection("sec2", "Second Section", [
+            createTextBlock("block2", "Text 2"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([testMod], []);
+
+      // Title item gets module title as sectionTitle
+      expect(result.items[0]?.sectionTitle).toBe("Test Module");
+      // Blocks get their section title
+      expect(result.items[1]?.sectionTitle).toBe("First Section");
+      expect(result.items[2]?.sectionTitle).toBe("Second Section");
+    });
+  });
+
+  describe("block type mapping", () => {
+    it("should map quiz blocks to quiz carousel type", () => {
+      const testMod = createTestModule(
+        "universal-test",
+        "Test Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            createQuizBlock("quiz1", "What is the answer?"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([testMod], []);
+
+      expect(result.items[1]?.type).toBe("quiz");
+    });
+
+    it("should map checklist blocks to checklist carousel type", () => {
+      const testMod = createTestModule(
+        "universal-test",
+        "Test Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            createChecklistBlock("checklist1", "My Checklist"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([testMod], []);
+
+      expect(result.items[1]?.type).toBe("checklist");
+    });
+
+    it("should map text, tip, warning to content carousel type", () => {
+      const testMod = createTestModule(
+        "universal-test",
+        "Test Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("text1", "Text"),
+            createTipBlock("tip1", "Tip"),
+            createWarningBlock("warning1", "Warning"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([testMod], []);
+
+      expect(result.items[1]?.type).toBe("content");
+      expect(result.items[2]?.type).toBe("content");
+      expect(result.items[3]?.type).toBe("content");
+    });
+  });
+
+  describe("paywall insertion", () => {
+    it("should insert paywall between free and premium modules", () => {
+      const freeModule = createTestModule(
+        "universal-test",
+        "Free Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Free content"),
+          ]),
+        ]
+      );
+
+      const premiumModule = createTestModule(
+        "company-google",
+        "Premium Module",
+        "company",
+        true,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Premium content"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([freeModule], [premiumModule]);
+
+      expect(result.paywallIndex).toBe(2); // After title + 1 block
+      expect(result.items[2]).toMatchObject({
+        id: "paywall",
+        type: "paywall",
+        moduleSlug: "paywall",
+        isPremium: false,
+      });
+    });
+
+    it("should not insert paywall when no premium modules", () => {
+      const freeModule = createTestModule(
+        "universal-test",
+        "Free Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Free content"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([freeModule], []);
+
+      expect(result.paywallIndex).toBeNull();
+      expect(result.items.find((item) => item.type === "paywall")).toBeUndefined();
+    });
+
+    it("should insert paywall at correct position with multiple free modules", () => {
+      const freeModule1 = createTestModule(
+        "universal-1",
+        "Free Module 1",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Content 1"),
+            createTextBlock("block2", "Content 2"),
+          ]),
+        ]
+      );
+
+      const freeModule2 = createTestModule(
+        "universal-2",
+        "Free Module 2",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Content 3"),
+          ]),
+        ]
+      );
+
+      const premiumModule = createTestModule(
+        "company-test",
+        "Premium Module",
+        "company",
+        true,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Premium content"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems(
+        [freeModule1, freeModule2],
+        [premiumModule]
+      );
+
+      // Free module 1: title + 2 blocks = 3 items
+      // Free module 2: title + 1 block = 2 items
+      // Total free items = 5, paywall at index 5
+      expect(result.paywallIndex).toBe(5);
+    });
+  });
+
+  describe("premium content handling", () => {
+    it("should mark premium module items as premium", () => {
+      const premiumModule = createTestModule(
+        "company-google",
+        "Premium Module",
+        "company",
+        true,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Premium content"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([], [premiumModule]);
+
+      // Skip paywall item (index 0), check title and block
+      expect(result.items[1]?.isPremium).toBe(true);
+      expect(result.items[2]?.isPremium).toBe(true);
+    });
+
+    it("should mark free module items as not premium", () => {
+      const freeModule = createTestModule(
+        "universal-test",
+        "Free Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Free content"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([freeModule], []);
+
+      expect(result.items[0]?.isPremium).toBe(false);
+      expect(result.items[1]?.isPremium).toBe(false);
+    });
+  });
+
+  describe("multiple modules", () => {
+    it("should flatten multiple modules in order", () => {
+      const module1 = createTestModule(
+        "universal-1",
+        "Module 1",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Content 1"),
+          ]),
+        ]
+      );
+
+      const module2 = createTestModule(
+        "company-google",
+        "Module 2",
+        "company",
+        true,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Content 2"),
+          ]),
+        ]
+      );
+
+      const module3 = createTestModule(
+        "role-swe",
+        "Module 3",
+        "role",
+        true,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Content 3"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([module1], [module2, module3]);
+
+      // Module 1: title + 1 block = 2 items
+      // Paywall = 1 item
+      // Module 2: title + 1 block = 2 items
+      // Module 3: title + 1 block = 2 items
+      // Total = 7 items
+      expect(result.totalItems).toBe(7);
+
+      // Check module order via moduleSlug
+      expect(result.items[0]?.moduleSlug).toBe("universal-1");
+      expect(result.items[1]?.moduleSlug).toBe("universal-1");
+      expect(result.items[2]?.moduleSlug).toBe("paywall");
+      expect(result.items[3]?.moduleSlug).toBe("company-google");
+      expect(result.items[4]?.moduleSlug).toBe("company-google");
+      expect(result.items[5]?.moduleSlug).toBe("role-swe");
+      expect(result.items[6]?.moduleSlug).toBe("role-swe");
+    });
+  });
+
+  describe("acceptance criteria: 3 modules with 10 blocks each → ~33 items", () => {
+    it("should produce approximately 33 items for 3 modules with 10 blocks each", () => {
+      // Create 3 modules, each with 10 blocks
+      const freeModule = createTestModule(
+        "universal-test",
+        "Free Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Content 1"),
+            createTextBlock("block2", "Content 2"),
+            createTextBlock("block3", "Content 3"),
+            createTextBlock("block4", "Content 4"),
+            createTextBlock("block5", "Content 5"),
+            createTextBlock("block6", "Content 6"),
+            createTextBlock("block7", "Content 7"),
+            createTextBlock("block8", "Content 8"),
+            createTextBlock("block9", "Content 9"),
+            createTextBlock("block10", "Content 10"),
+          ]),
+        ]
+      );
+
+      const premiumModule1 = createTestModule(
+        "company-google",
+        "Premium Module 1",
+        "company",
+        true,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Content 1"),
+            createTextBlock("block2", "Content 2"),
+            createTextBlock("block3", "Content 3"),
+            createTextBlock("block4", "Content 4"),
+            createTextBlock("block5", "Content 5"),
+            createTextBlock("block6", "Content 6"),
+            createTextBlock("block7", "Content 7"),
+            createTextBlock("block8", "Content 8"),
+            createTextBlock("block9", "Content 9"),
+            createTextBlock("block10", "Content 10"),
+          ]),
+        ]
+      );
+
+      const premiumModule2 = createTestModule(
+        "role-swe",
+        "Premium Module 2",
+        "role",
+        true,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Content 1"),
+            createTextBlock("block2", "Content 2"),
+            createTextBlock("block3", "Content 3"),
+            createTextBlock("block4", "Content 4"),
+            createTextBlock("block5", "Content 5"),
+            createTextBlock("block6", "Content 6"),
+            createTextBlock("block7", "Content 7"),
+            createTextBlock("block8", "Content 8"),
+            createTextBlock("block9", "Content 9"),
+            createTextBlock("block10", "Content 10"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems(
+        [freeModule],
+        [premiumModule1, premiumModule2]
+      );
+
+      // 3 modules × (1 title + 10 blocks) = 33 items + 1 paywall = 34 items
+      expect(result.totalItems).toBe(34);
+      expect(result.paywallIndex).toBe(11); // After free module (1 title + 10 blocks)
+    });
+  });
+
+  describe("content normalization", () => {
+    it("should handle blocks with content as object", () => {
+      // This simulates how JSON modules store content
+      const testMod = createTestModule(
+        "universal-test",
+        "Test Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            {
+              id: "text1",
+              type: "text",
+              content: { text: "Nested text content" },
+            } as unknown as ContentBlock,
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([testMod], []);
+
+      expect(result.items[1]?.content).toMatchObject({
+        id: "text1",
+        type: "text",
+        content: "Nested text content",
+      });
+    });
+
+    it("should handle quiz blocks with nested content", () => {
+      const testMod = createTestModule(
+        "universal-test",
+        "Test Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            {
+              id: "quiz1",
+              type: "quiz",
+              content: {
+                question: "What is the answer?",
+                options: [
+                  { id: "a", text: "Option A", isCorrect: true },
+                  { id: "b", text: "Option B", isCorrect: false },
+                ],
+                explanation: "Because A is correct",
+              },
+            } as unknown as ContentBlock,
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([testMod], []);
+
+      expect(result.items[1]?.type).toBe("quiz");
+      expect(result.items[1]?.content).toMatchObject({
+        id: "quiz1",
+        type: "quiz",
+        question: "What is the answer?",
+        explanation: "Because A is correct",
+      });
+    });
+
+    it("should handle checklist blocks with nested content", () => {
+      const testMod = createTestModule(
+        "universal-test",
+        "Test Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            {
+              id: "checklist1",
+              type: "checklist",
+              content: {
+                title: "My Checklist",
+                items: [
+                  { id: "item1", text: "Item 1", required: true },
+                  { id: "item2", text: "Item 2", required: false },
+                ],
+              },
+            } as unknown as ContentBlock,
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([testMod], []);
+
+      expect(result.items[1]?.type).toBe("checklist");
+      expect(result.items[1]?.content).toMatchObject({
+        id: "checklist1",
+        type: "checklist",
+        title: "My Checklist",
+      });
+    });
+
+    it("should handle tip and warning blocks with nested content", () => {
+      const testMod = createTestModule(
+        "universal-test",
+        "Test Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            {
+              id: "tip1",
+              type: "tip",
+              content: { text: "This is a tip" },
+            } as unknown as ContentBlock,
+            {
+              id: "warning1",
+              type: "warning",
+              content: { text: "This is a warning" },
+            } as unknown as ContentBlock,
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([testMod], []);
+
+      expect(result.items[1]?.content).toMatchObject({
+        id: "tip1",
+        type: "tip",
+        content: "This is a tip",
+      });
+      expect(result.items[2]?.content).toMatchObject({
+        id: "warning1",
+        type: "warning",
+        content: "This is a warning",
+      });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty free modules array", () => {
+      const premiumModule = createTestModule(
+        "company-google",
+        "Premium Module",
+        "company",
+        true,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Content"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([], [premiumModule]);
+
+      expect(result.items).toHaveLength(3); // paywall + title + 1 block
+      expect(result.paywallIndex).toBe(0);
+    });
+
+    it("should handle empty premium modules array", () => {
+      const freeModule = createTestModule(
+        "universal-test",
+        "Free Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Content"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([freeModule], []);
+
+      expect(result.paywallIndex).toBeNull();
+    });
+
+    it("should handle both arrays empty", () => {
+      const result = flattenToCarouselItems([], []);
+
+      expect(result.items).toHaveLength(0);
+      expect(result.paywallIndex).toBeNull();
+      expect(result.totalItems).toBe(0);
+    });
+
+    it("should handle module with empty sections", () => {
+      const testMod = createTestModule(
+        "universal-test",
+        "Empty Module",
+        "universal",
+        false,
+        []
+      );
+
+      const result = flattenToCarouselItems([testMod], []);
+
+      expect(result.items).toHaveLength(1); // Only title
+    });
+
+    it("should handle section with empty blocks", () => {
+      const testMod = createTestModule(
+        "universal-test",
+        "Test Module",
+        "universal",
+        false,
+        [createTestSection("sec1", "Empty Section", [])]
+      );
+
+      const result = flattenToCarouselItems([testMod], []);
+
+      expect(result.items).toHaveLength(1); // Only title
+    });
+
+    it("should handle blocks without id", () => {
+      const testMod = createTestModule(
+        "universal-test",
+        "Test Module",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            {
+              type: "text",
+              content: "Text without id",
+            } as unknown as ContentBlock,
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([testMod], []);
+
+      // Should generate an id
+      expect(result.items[1]?.id).toContain("universal-test");
+    });
+  });
+
+  describe("unique item IDs", () => {
+    it("should generate unique IDs for all items", () => {
+      const module1 = createTestModule(
+        "universal-1",
+        "Module 1",
+        "universal",
+        false,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Content 1"),
+            createTextBlock("block2", "Content 2"),
+          ]),
+        ]
+      );
+
+      const module2 = createTestModule(
+        "company-google",
+        "Module 2",
+        "company",
+        true,
+        [
+          createTestSection("sec1", "Section 1", [
+            createTextBlock("block1", "Content 3"),
+          ]),
+        ]
+      );
+
+      const result = flattenToCarouselItems([module1], [module2]);
+
+      const ids = result.items.map((item) => item.id);
+      const uniqueIds = new Set(ids);
+
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+  });
+});
+
+describe("getModuleBlockCount", () => {
+  it("should return total block count across all sections", () => {
+    const testMod = createTestModule(
+      "universal-test",
+      "Test Module",
+      "universal",
+      false,
+      [
+        createTestSection("sec1", "Section 1", [
+          createTextBlock("block1", "Content 1"),
+          createTextBlock("block2", "Content 2"),
+        ]),
+        createTestSection("sec2", "Section 2", [
+          createTextBlock("block3", "Content 3"),
+        ]),
+      ]
+    );
+
+    expect(getModuleBlockCount(testMod)).toBe(3);
+  });
+
+  it("should return 0 for module with no sections", () => {
+    const testMod = createTestModule(
+      "universal-test",
+      "Empty Module",
+      "universal",
+      false,
+      []
+    );
+
+    expect(getModuleBlockCount(testMod)).toBe(0);
+  });
+});
+
+describe("getModuleItemCount", () => {
+  it("should return block count plus 1 for title", () => {
+    const testMod = createTestModule(
+      "universal-test",
+      "Test Module",
+      "universal",
+      false,
+      [
+        createTestSection("sec1", "Section 1", [
+          createTextBlock("block1", "Content 1"),
+          createTextBlock("block2", "Content 2"),
+        ]),
+      ]
+    );
+
+    expect(getModuleItemCount(testMod)).toBe(3); // 2 blocks + 1 title
+  });
+
+  it("should return 1 for module with no blocks", () => {
+    const testMod = createTestModule(
+      "universal-test",
+      "Empty Module",
+      "universal",
+      false,
+      []
+    );
+
+    expect(getModuleItemCount(testMod)).toBe(1); // Just title
+  });
+});

--- a/src/lib/carousel/flatten-modules.ts
+++ b/src/lib/carousel/flatten-modules.ts
@@ -1,0 +1,309 @@
+/**
+ * Flatten modules to carousel items
+ * Converts hierarchical module/section/block structure to flat CarouselItem array
+ */
+
+import type { Module, ContentBlock, ContentBlockType } from "@/types/module";
+import type { CarouselItem, CarouselItemType } from "@/types/carousel";
+
+/**
+ * Result of flattening modules
+ */
+export interface FlattenResult {
+  /** All carousel items in order */
+  items: CarouselItem[];
+  /** Index where paywall appears (null if no premium content) */
+  paywallIndex: number | null;
+  /** Total number of items */
+  totalItems: number;
+}
+
+/**
+ * Special content block for module title items
+ */
+interface ModuleTitleBlock {
+  id: string;
+  type: "header";
+  content: string;
+  level: 1;
+}
+
+/**
+ * Special content block for paywall items
+ */
+interface PaywallBlock {
+  id: string;
+  type: "text";
+  content: string;
+}
+
+/**
+ * Map ContentBlockType to CarouselItemType
+ */
+function mapBlockTypeToCarouselType(blockType: ContentBlockType): CarouselItemType {
+  switch (blockType) {
+    case "quiz":
+      return "quiz";
+    case "checklist":
+      return "checklist";
+    default:
+      return "content";
+  }
+}
+
+/**
+ * Extract the text content from a block for creating content blocks
+ * Handles both string content and object content formats
+ */
+function extractBlockContent(block: ContentBlock): ContentBlock {
+  // If block.content is an object (from JSON), we need to normalize it
+  const rawBlock = block as unknown as Record<string, unknown>;
+
+  if (rawBlock.content && typeof rawBlock.content === "object") {
+    const contentObj = rawBlock.content as Record<string, unknown>;
+
+    // Handle different block types
+    switch (block.type) {
+      case "text":
+      case "tip":
+      case "warning":
+        return {
+          id: block.id,
+          type: block.type,
+          content: (contentObj.text as string) || "",
+        } as ContentBlock;
+
+      case "header":
+        return {
+          id: block.id,
+          type: "header",
+          content: (contentObj.text as string) || "",
+          level: (contentObj.level as 1 | 2 | 3) || 2,
+        } as ContentBlock;
+
+      case "quote":
+        return {
+          id: block.id,
+          type: "quote",
+          content: (contentObj.text as string) || "",
+          author: contentObj.author as string | undefined,
+        } as ContentBlock;
+
+      case "quiz":
+        return {
+          id: block.id,
+          type: "quiz",
+          question: (contentObj.question as string) || "",
+          options: (contentObj.options as Array<{ id: string; text: string; isCorrect: boolean }>) || [],
+          multiSelect: contentObj.multiSelect as boolean | undefined,
+          explanation: contentObj.explanation as string | undefined,
+        } as ContentBlock;
+
+      case "checklist":
+        return {
+          id: block.id,
+          type: "checklist",
+          title: contentObj.title as string | undefined,
+          items: (contentObj.items as Array<{ id: string; text: string; required?: boolean }>) || [],
+        } as ContentBlock;
+
+      case "video":
+        return {
+          id: block.id,
+          type: "video",
+          url: (contentObj.url as string) || "",
+          title: contentObj.title as string | undefined,
+          duration: contentObj.duration as number | undefined,
+        } as ContentBlock;
+
+      case "audio":
+        return {
+          id: block.id,
+          type: "audio",
+          url: (contentObj.url as string) || "",
+          title: contentObj.title as string | undefined,
+          duration: contentObj.duration as number | undefined,
+        } as ContentBlock;
+
+      case "image":
+        return {
+          id: block.id,
+          type: "image",
+          url: (contentObj.url as string) || "",
+          alt: (contentObj.alt as string) || "",
+          caption: contentObj.caption as string | undefined,
+        } as ContentBlock;
+
+      case "infographic":
+        return {
+          id: block.id,
+          type: "infographic",
+          url: (contentObj.url as string) || "",
+          alt: (contentObj.alt as string) || "",
+          caption: contentObj.caption as string | undefined,
+        } as ContentBlock;
+
+      case "animation":
+        return {
+          id: block.id,
+          type: "animation",
+          animationUrl: (contentObj.animationUrl as string) || "",
+          loop: contentObj.loop as boolean | undefined,
+          autoplay: contentObj.autoplay as boolean | undefined,
+        } as ContentBlock;
+    }
+  }
+
+  // Block is already in the correct format
+  return block;
+}
+
+/**
+ * Create a module title item
+ */
+function createModuleTitleItem(
+  mod: Module,
+  order: number
+): CarouselItem {
+  const titleBlock: ModuleTitleBlock = {
+    id: `${mod.slug}-title`,
+    type: "header",
+    content: mod.title,
+    level: 1,
+  };
+
+  return {
+    id: `${mod.slug}-title`,
+    type: "content",
+    content: titleBlock as unknown as ContentBlock,
+    moduleSlug: mod.slug,
+    isPremium: mod.isPremium,
+    sectionTitle: mod.title,
+    order,
+  };
+}
+
+/**
+ * Create a paywall item
+ */
+function createPaywallItem(order: number): CarouselItem {
+  const paywallBlock: PaywallBlock = {
+    id: "paywall",
+    type: "text",
+    content: "Unlock premium content to continue your preparation journey.",
+  };
+
+  return {
+    id: "paywall",
+    type: "paywall",
+    content: paywallBlock as unknown as ContentBlock,
+    moduleSlug: "paywall",
+    isPremium: false, // The paywall item itself is not premium
+    sectionTitle: "Premium Content",
+    order,
+  };
+}
+
+/**
+ * Flatten a single module's content into carousel items
+ */
+function flattenModule(
+  mod: Module,
+  startOrder: number
+): CarouselItem[] {
+  const items: CarouselItem[] = [];
+  let currentOrder = startOrder;
+
+  // Add module title item
+  items.push(createModuleTitleItem(mod, currentOrder));
+  currentOrder++;
+
+  // Process each section
+  for (const section of mod.sections) {
+    // Process each block in the section
+    for (const block of section.blocks) {
+      // Generate an ID for blocks that don't have one
+      const blockId = block.id || `${mod.slug}-${section.id}-${items.length}`;
+
+      // Normalize the block content
+      const normalizedBlock = extractBlockContent({
+        ...block,
+        id: blockId,
+      });
+
+      const item: CarouselItem = {
+        id: `${mod.slug}-${blockId}`,
+        type: mapBlockTypeToCarouselType(block.type),
+        content: normalizedBlock,
+        moduleSlug: mod.slug,
+        isPremium: mod.isPremium,
+        sectionTitle: section.title,
+        order: currentOrder,
+      };
+
+      items.push(item);
+      currentOrder++;
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Flatten modules to carousel items
+ *
+ * @param freeModules - Modules that are free (before paywall)
+ * @param premiumModules - Modules that require payment (after paywall)
+ * @returns FlattenResult with all items, paywall index, and total count
+ */
+export function flattenToCarouselItems(
+  freeModules: Module[],
+  premiumModules: Module[]
+): FlattenResult {
+  const items: CarouselItem[] = [];
+  let currentOrder = 0;
+
+  // Flatten free modules first
+  for (const freeMod of freeModules) {
+    const moduleItems = flattenModule(freeMod, currentOrder);
+    items.push(...moduleItems);
+    currentOrder += moduleItems.length;
+  }
+
+  // Determine paywall index
+  let paywallIndex: number | null = null;
+
+  // Only add paywall if there are premium modules
+  if (premiumModules.length > 0) {
+    paywallIndex = currentOrder;
+    items.push(createPaywallItem(currentOrder));
+    currentOrder++;
+  }
+
+  // Flatten premium modules after paywall
+  for (const premiumMod of premiumModules) {
+    const moduleItems = flattenModule(premiumMod, currentOrder);
+    items.push(...moduleItems);
+    currentOrder += moduleItems.length;
+  }
+
+  return {
+    items,
+    paywallIndex,
+    totalItems: items.length,
+  };
+}
+
+/**
+ * Get the number of blocks in a module (excluding title)
+ */
+export function getModuleBlockCount(mod: Module): number {
+  return mod.sections.reduce((total, section) => total + section.blocks.length, 0);
+}
+
+/**
+ * Get the total number of items a module will produce (including title)
+ */
+export function getModuleItemCount(mod: Module): number {
+  return getModuleBlockCount(mod) + 1; // +1 for title
+}

--- a/src/lib/carousel/index.ts
+++ b/src/lib/carousel/index.ts
@@ -8,3 +8,10 @@ export {
   getModuleOrderIndex,
   type CarouselModulesResult,
 } from "./load-modules";
+
+export {
+  flattenToCarouselItems,
+  getModuleBlockCount,
+  getModuleItemCount,
+  type FlattenResult,
+} from "./flatten-modules";


### PR DESCRIPTION
## Summary
- Create `flattenToCarouselItems()` to convert module hierarchy to flat CarouselItem array
- Each content block becomes one CarouselItem with proper type mapping (quiz, checklist, content)
- Insert module title item at start of each module (header with level 1)
- Insert paywall item between free and premium modules (only if premium modules exist)
- Add helper functions: `getModuleBlockCount()`, `getModuleItemCount()`

## Test plan
- [x] 29 new unit tests covering all functionality
- [x] Acceptance criteria verified: 3 modules with 10 blocks each → 34 items (33 + paywall)
- [x] Lint passes
- [x] Type check passes
- [x] Build succeeds

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)