### PR TITLE
Add carousel progress schema fields (#133)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -2677,3 +2677,31 @@ All Stage 5 (Launch) code issues are now closed:
   - Insert module title item at start of each module ✓
   - Insert paywall item between free and premium ✓
   - Test: 3 modules with 10 blocks each → ~33 items (34 = 33 items + 1 paywall) ✓
+
+### 2026-01-19 - Issue #133: C1: Update progress schema
+
+**Completed:**
+- Created Supabase migration for carousel-specific progress fields
+- Added 3 new columns to `journey_progress` table:
+  - `current_item_index INTEGER` - carousel position tracking
+  - `module_slug TEXT` - current module being viewed
+  - `completed_items TEXT[]` - array of completed carousel item IDs
+- Maintains backward compatibility with existing journey progress data
+- Updated `JourneyProgressRow` TypeScript interface with new fields
+
+**Files Created:**
+- `supabase/migrations/20260119000001_carousel_progress.sql`
+
+**Files Modified:**
+- `src/lib/journey/supabase-sync.ts` - Added carousel fields to JourneyProgressRow interface
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - 440 journey/carousel tests pass
+- All acceptance criteria verified:
+  - Migration adds `current_item_index INTEGER` ✓
+  - Migration adds `module_slug TEXT` ✓
+  - Migration adds `completed_items TEXT[]` ✓
+  - Existing data preserved (backward compatible) ✓

--- a/src/lib/journey/supabase-sync.ts
+++ b/src/lib/journey/supabase-sync.ts
@@ -23,6 +23,10 @@ export interface JourneyProgressRow {
   }>;
   last_updated: string;
   created_at: string;
+  // Carousel-specific fields (added in 20260119000001_carousel_progress.sql)
+  current_item_index: number | null;
+  module_slug: string | null;
+  completed_items: string[];
 }
 
 /**

--- a/supabase/migrations/20260119000001_carousel_progress.sql
+++ b/supabase/migrations/20260119000001_carousel_progress.sql
@@ -1,0 +1,24 @@
+-- Add carousel-specific fields to journey_progress table
+-- Supports new carousel UX while maintaining backward compatibility
+
+-- Add current_item_index for carousel position tracking
+ALTER TABLE journey_progress
+ADD COLUMN IF NOT EXISTS current_item_index INTEGER;
+
+-- Add module_slug to track current module in carousel
+ALTER TABLE journey_progress
+ADD COLUMN IF NOT EXISTS module_slug TEXT;
+
+-- Add completed_items array for carousel item tracking (parallel to completed_steps)
+ALTER TABLE journey_progress
+ADD COLUMN IF NOT EXISTS completed_items TEXT[] NOT NULL DEFAULT '{}';
+
+-- Add comment explaining fields
+COMMENT ON COLUMN journey_progress.current_item_index IS 'Current item position in carousel (0-indexed)';
+COMMENT ON COLUMN journey_progress.module_slug IS 'Slug of the current module being viewed';
+COMMENT ON COLUMN journey_progress.completed_items IS 'Array of completed carousel item IDs';
+
+-- Create index for module_slug queries (useful for analytics)
+CREATE INDEX IF NOT EXISTS idx_journey_progress_module_slug
+  ON journey_progress(module_slug)
+  WHERE module_slug IS NOT NULL;


### PR DESCRIPTION
## Summary
- Create migration to add carousel-specific fields to `journey_progress` table
- Add `current_item_index INTEGER` for carousel position tracking
- Add `module_slug TEXT` for current module tracking  
- Add `completed_items TEXT[]` for tracking completed carousel items
- Update TypeScript `JourneyProgressRow` interface with new fields

## Test plan
- [x] Migration file is valid SQL
- [x] TypeScript type-check passes
- [x] Lint passes
- [x] Build passes
- [x] All journey/carousel tests pass (440 tests)
- [x] Backward compatible with existing data (uses IF NOT EXISTS, nullable new fields)

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)