### PR TITLE
Switch default font to Poppins using next/font

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,7 +17,7 @@
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-poppins), "Poppins", sans-serif;
 }
 
 /* Reduced motion support - disable animations for users who prefer it */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,13 @@
 import type { Metadata } from "next";
+import { Poppins } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
+
+const poppins = Poppins({
+  subsets: ["latin"],
+  weight: ["300", "400", "500", "600", "700"],
+  variable: "--font-poppins",
+});
 
 export const metadata: Metadata = {
   title: "Ace That Interview - Interview Prep Platform",
@@ -14,7 +21,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>
+      <body className={poppins.className}>
         <Providers>{children}</Providers>
       </body>
     </html>


### PR DESCRIPTION
- Import Poppins from next/font/google with weights 300-700
- Apply font className to body element in layout
- Update globals.css to use Poppins font-family