### PR TITLE
Generate company trivia for E-commerce/Retail batch (#90)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -3084,3 +3084,55 @@ All Stage 5 (Launch) code issues are now closed:
 - Quiz items have exactly 3 wrong options
 - All items have source_url and source_date
 
+
+### 2026-01-19 - Issue #90: Generate company trivia: E-commerce/Retail batch
+
+**Completed:**
+- Created trivia generation script `/scripts/generate-trivia-ecommerce.ts`
+- Generated trivia for 11 E-commerce/Retail companies:
+  - Shopify, Etsy, Wayfair, Chewy, Target
+  - Walmart, Costco, Home Depot, Best Buy, Nike, Lululemon
+- Generated 149 trivia items total (11-14 items per company)
+- Output files in `/data/generated/trivia/{company}.json`
+
+**Trivia Types Generated:**
+- Founding (quiz, flashcard, factoid)
+- Headquarters (quiz, flashcard)
+- CEO/Executive (quiz, flashcard)
+- Mission statement (factoid, flashcard)
+- Products (quiz, factoid)
+- Acquisitions (quiz, factoid, flashcard)
+
+**Format per Item:**
+- `company_slug` - company identifier
+- `fact_type` - founding, hq, mission, product, news, exec, acquisition
+- `format` - quiz, flashcard, factoid
+- `question` - question text (null for factoids)
+- `answer` - correct answer
+- `options` - 3 wrong answers (for quiz format only)
+- `source_url` - Wikipedia source link
+- `source_date` - date of generation
+
+**Files Created:**
+- `scripts/generate-trivia-ecommerce.ts` - trivia generation script
+- `data/generated/trivia/shopify.json` (14 items)
+- `data/generated/trivia/etsy.json` (14 items)
+- `data/generated/trivia/wayfair.json` (13 items)
+- `data/generated/trivia/chewy.json` (11 items)
+- `data/generated/trivia/target.json` (14 items)
+- `data/generated/trivia/walmart.json` (14 items)
+- `data/generated/trivia/costco.json` (14 items)
+- `data/generated/trivia/home-depot.json` (14 items)
+- `data/generated/trivia/best-buy.json` (14 items)
+- `data/generated/trivia/nike.json` (14 items)
+- `data/generated/trivia/lululemon.json` (13 items)
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - 2163 passed, 2 todo, 12 pre-existing failures (unrelated to this change)
+- All trivia files conform to expected schema
+- Quiz items have exactly 3 wrong options
+- All items have source_url and source_date
+

--- a/data/generated/trivia/best-buy.json
+++ b/data/generated/trivia/best-buy.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "best-buy",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Best Buy founded?",
+    "answer": "1966",
+    "options": [
+      "1958",
+      "1962",
+      "1972"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Best_Buy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "best-buy",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Best Buy?",
+    "answer": "Richard Schulze",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Best_Buy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "best-buy",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Best Buy was founded in 1966 by Richard Schulze.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Best_Buy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "best-buy",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Best Buy's headquarters located?",
+    "answer": "Richfield, Minnesota",
+    "options": [
+      "Seattle, Washington",
+      "San Francisco, California",
+      "New York, New York"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Best_Buy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "best-buy",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Best Buy headquartered in?",
+    "answer": "Richfield, Minnesota",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Best_Buy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "best-buy",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Best Buy?",
+    "answer": "Corie Barry",
+    "options": [
+      "Doug McMillon",
+      "Brian Cornell",
+      "Ted Decker"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Best_Buy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "best-buy",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Best Buy as CEO?",
+    "answer": "Corie Barry",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Best_Buy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "best-buy",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Best Buy's mission is \"To enrich lives through technology\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Best_Buy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "best-buy",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Best Buy's mission statement?",
+    "answer": "To enrich lives through technology",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Best_Buy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "best-buy",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Best Buy product or service?",
+    "answer": "Consumer Electronics",
+    "options": [
+      "E-commerce Platform",
+      "Warehouse Clubs",
+      "Athletic Footwear"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Best_Buy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "best-buy",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Best Buy offers Consumer Electronics, Geek Squad, Best Buy Business, Best Buy Health.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Best_Buy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "best-buy",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Best Buy acquire in 2018?",
+    "answer": "GreatCall",
+    "options": [
+      "Deliverr",
+      "6 River Systems",
+      "Oberlo"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Best_Buy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "best-buy",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Best Buy acquired GreatCall in 2018.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Best_Buy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "best-buy",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did Best Buy acquire Critical Signal Technologies?",
+    "answer": "2019",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Best_Buy",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/chewy.json
+++ b/data/generated/trivia/chewy.json
@@ -1,0 +1,128 @@
+[
+  {
+    "company_slug": "chewy",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Chewy founded?",
+    "answer": "2011",
+    "options": [
+      "2006",
+      "2009",
+      "2014"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Chewy_(company)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "chewy",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Chewy?",
+    "answer": "Ryan Cohen and Michael Day",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Chewy_(company)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "chewy",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Chewy was founded in 2011 by Ryan Cohen and Michael Day.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Chewy_(company)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "chewy",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Chewy's headquarters located?",
+    "answer": "Dania Beach, Florida",
+    "options": [
+      "Seattle, Washington",
+      "San Francisco, California",
+      "New York, New York"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Chewy_(company)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "chewy",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Chewy headquartered in?",
+    "answer": "Dania Beach, Florida",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Chewy_(company)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "chewy",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Chewy?",
+    "answer": "Sumit Singh",
+    "options": [
+      "Niraj Shah",
+      "Josh Silverman",
+      "Brian Cornell"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Chewy_(company)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "chewy",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Chewy as CEO?",
+    "answer": "Sumit Singh",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Chewy_(company)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "chewy",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Chewy's mission is \"To be the most trusted and convenient destination for pet parents\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Chewy_(company)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "chewy",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Chewy's mission statement?",
+    "answer": "To be the most trusted and convenient destination for pet parents",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Chewy_(company)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "chewy",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Chewy product or service?",
+    "answer": "Pet Food",
+    "options": [
+      "E-commerce Platform",
+      "Warehouse Clubs",
+      "Consumer Electronics"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Chewy_(company)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "chewy",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Chewy offers Pet Food, Pet Supplies, Chewy Pharmacy, Autoship Subscriptions.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Chewy_(company)",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/costco.json
+++ b/data/generated/trivia/costco.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "costco",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Costco founded?",
+    "answer": "1983",
+    "options": [
+      "1978",
+      "1981",
+      "1986"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Costco",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "costco",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Costco?",
+    "answer": "James Sinegal and Jeffrey Brotman",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Costco",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "costco",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Costco was founded in 1983 by James Sinegal and Jeffrey Brotman.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Costco",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "costco",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Costco's headquarters located?",
+    "answer": "Issaquah, Washington",
+    "options": [
+      "Seattle, Washington",
+      "San Francisco, California",
+      "New York, New York"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Costco",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "costco",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Costco headquartered in?",
+    "answer": "Issaquah, Washington",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Costco",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "costco",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Costco?",
+    "answer": "Ron Vachris",
+    "options": [
+      "Doug McMillon",
+      "Brian Cornell",
+      "Ted Decker"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Costco",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "costco",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Costco as CEO?",
+    "answer": "Ron Vachris",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Costco",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "costco",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Costco's mission is \"To continually provide our members with quality goods and services at the lowest possible prices\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Costco",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "costco",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Costco's mission statement?",
+    "answer": "To continually provide our members with quality goods and services at the lowest possible prices",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Costco",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "costco",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Costco product or service?",
+    "answer": "Warehouse Clubs",
+    "options": [
+      "E-commerce Platform",
+      "Consumer Electronics",
+      "Athletic Footwear"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Costco",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "costco",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Costco offers Warehouse Clubs, Kirkland Signature, Costco Travel, Costco Wholesale.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Costco",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "costco",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Costco acquire in 1993?",
+    "answer": "Price Club",
+    "options": [
+      "Deliverr",
+      "6 River Systems",
+      "Oberlo"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Costco",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "costco",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Costco acquired Price Club in 1993.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Costco",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "costco",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did Costco acquire Innovel Solutions?",
+    "answer": "2020",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Costco",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/etsy.json
+++ b/data/generated/trivia/etsy.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "etsy",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Etsy founded?",
+    "answer": "2005",
+    "options": [
+      "2000",
+      "2003",
+      "2008"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Etsy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "etsy",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Etsy?",
+    "answer": "Rob Kalin and Chris Maguire and others",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Etsy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "etsy",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Etsy was founded in 2005 by Rob Kalin and Chris Maguire and others.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Etsy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "etsy",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Etsy's headquarters located?",
+    "answer": "Brooklyn, New York",
+    "options": [
+      "Seattle, Washington",
+      "San Francisco, California",
+      "New York, New York"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Etsy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "etsy",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Etsy headquartered in?",
+    "answer": "Brooklyn, New York",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Etsy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "etsy",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Etsy?",
+    "answer": "Josh Silverman",
+    "options": [
+      "Tobias Lütke",
+      "Brian Cornell",
+      "Doug McMillon"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Etsy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "etsy",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Etsy as CEO?",
+    "answer": "Josh Silverman",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Etsy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "etsy",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Etsy's mission is \"To keep commerce human\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Etsy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "etsy",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Etsy's mission statement?",
+    "answer": "To keep commerce human",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Etsy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "etsy",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Etsy product or service?",
+    "answer": "Etsy Marketplace",
+    "options": [
+      "E-commerce Platform",
+      "Warehouse Clubs",
+      "Consumer Electronics"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Etsy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "etsy",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Etsy offers Etsy Marketplace, Etsy Payments, Etsy Ads, Pattern.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Etsy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "etsy",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Etsy acquire in 2021?",
+    "answer": "Depop",
+    "options": [
+      "Deliverr",
+      "6 River Systems",
+      "Oberlo"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Etsy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "etsy",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Etsy acquired Depop in 2021.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Etsy",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "etsy",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did Etsy acquire Elo7?",
+    "answer": "2021",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Etsy",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/home-depot.json
+++ b/data/generated/trivia/home-depot.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "home-depot",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was The Home Depot founded?",
+    "answer": "1978",
+    "options": [
+      "1970",
+      "1974",
+      "1984"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/The_Home_Depot",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "home-depot",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded The Home Depot?",
+    "answer": "Bernie Marcus and Arthur Blank and others",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Home_Depot",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "home-depot",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "The Home Depot was founded in 1978 by Bernie Marcus and Arthur Blank and others.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Home_Depot",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "home-depot",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is The Home Depot's headquarters located?",
+    "answer": "Atlanta, Georgia",
+    "options": [
+      "Seattle, Washington",
+      "San Francisco, California",
+      "New York, New York"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/The_Home_Depot",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "home-depot",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is The Home Depot headquartered in?",
+    "answer": "Atlanta, Georgia",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Home_Depot",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "home-depot",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of The Home Depot?",
+    "answer": "Ted Decker",
+    "options": [
+      "Doug McMillon",
+      "Brian Cornell",
+      "Ron Vachris"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/The_Home_Depot",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "home-depot",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads The Home Depot as CEO?",
+    "answer": "Ted Decker",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Home_Depot",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "home-depot",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "The Home Depot's mission is \"To provide the highest level of service, the broadest selection of products, and the most competitive prices\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Home_Depot",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "home-depot",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is The Home Depot's mission statement?",
+    "answer": "To provide the highest level of service, the broadest selection of products, and the most competitive prices",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Home_Depot",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "home-depot",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a The Home Depot product or service?",
+    "answer": "Home Improvement",
+    "options": [
+      "E-commerce Platform",
+      "Warehouse Clubs",
+      "Consumer Electronics"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/The_Home_Depot",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "home-depot",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "The Home Depot offers Home Improvement, Pro Services, Tool Rental, Installation Services.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Home_Depot",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "home-depot",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did The Home Depot acquire in 2020?",
+    "answer": "HD Supply",
+    "options": [
+      "Deliverr",
+      "6 River Systems",
+      "Oberlo"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/The_Home_Depot",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "home-depot",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "The Home Depot acquired HD Supply in 2020.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Home_Depot",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "home-depot",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did The Home Depot acquire Interline Brands?",
+    "answer": "2015",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Home_Depot",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/lululemon.json
+++ b/data/generated/trivia/lululemon.json
@@ -1,0 +1,152 @@
+[
+  {
+    "company_slug": "lululemon",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Lululemon founded?",
+    "answer": "1998",
+    "options": [
+      "1993",
+      "1996",
+      "2001"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Lululemon_Athletica",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "lululemon",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Lululemon?",
+    "answer": "Chip Wilson",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Lululemon_Athletica",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "lululemon",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Lululemon was founded in 1998 by Chip Wilson.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Lululemon_Athletica",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "lululemon",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Lululemon's headquarters located?",
+    "answer": "Vancouver, British Columbia, Canada",
+    "options": [
+      "Seattle, Washington",
+      "San Francisco, California",
+      "New York, New York"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Lululemon_Athletica",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "lululemon",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Lululemon headquartered in?",
+    "answer": "Vancouver, British Columbia, Canada",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Lululemon_Athletica",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "lululemon",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Lululemon?",
+    "answer": "Calvin McDonald",
+    "options": [
+      "Elliott Hill",
+      "Doug McMillon",
+      "Brian Cornell"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Lululemon_Athletica",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "lululemon",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Lululemon as CEO?",
+    "answer": "Calvin McDonald",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Lululemon_Athletica",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "lululemon",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Lululemon's mission is \"To elevate human potential by helping people feel their best\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Lululemon_Athletica",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "lululemon",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Lululemon's mission statement?",
+    "answer": "To elevate human potential by helping people feel their best",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Lululemon_Athletica",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "lululemon",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Lululemon product or service?",
+    "answer": "Athletic Apparel",
+    "options": [
+      "E-commerce Platform",
+      "Warehouse Clubs",
+      "Consumer Electronics"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Lululemon_Athletica",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "lululemon",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Lululemon offers Athletic Apparel, Yoga Wear, Running Gear, Accessories.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Lululemon_Athletica",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "lululemon",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Lululemon acquire in 2020?",
+    "answer": "Mirror",
+    "options": [
+      "Deliverr",
+      "6 River Systems",
+      "Oberlo"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Lululemon_Athletica",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "lululemon",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Lululemon acquired Mirror in 2020.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Lululemon_Athletica",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/nike.json
+++ b/data/generated/trivia/nike.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "nike",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Nike founded?",
+    "answer": "1964",
+    "options": [
+      "1956",
+      "1960",
+      "1970"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Nike,_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "nike",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Nike?",
+    "answer": "Bill Bowerman and Phil Knight",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Nike,_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "nike",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Nike was founded in 1964 by Bill Bowerman and Phil Knight.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Nike,_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "nike",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Nike's headquarters located?",
+    "answer": "Beaverton, Oregon",
+    "options": [
+      "Seattle, Washington",
+      "San Francisco, California",
+      "New York, New York"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Nike,_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "nike",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Nike headquartered in?",
+    "answer": "Beaverton, Oregon",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Nike,_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "nike",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Nike?",
+    "answer": "Elliott Hill",
+    "options": [
+      "Doug McMillon",
+      "Calvin McDonald",
+      "Brian Cornell"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Nike,_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "nike",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Nike as CEO?",
+    "answer": "Elliott Hill",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Nike,_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "nike",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Nike's mission is \"To bring inspiration and innovation to every athlete in the world\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Nike,_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "nike",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Nike's mission statement?",
+    "answer": "To bring inspiration and innovation to every athlete in the world",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Nike,_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "nike",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Nike product or service?",
+    "answer": "Athletic Footwear",
+    "options": [
+      "E-commerce Platform",
+      "Warehouse Clubs",
+      "Consumer Electronics"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Nike,_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "nike",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Nike offers Athletic Footwear, Athletic Apparel, Nike+, Air Jordan.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Nike,_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "nike",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Nike acquire in 2003?",
+    "answer": "Converse",
+    "options": [
+      "Deliverr",
+      "6 River Systems",
+      "Oberlo"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Nike,_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "nike",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Nike acquired Converse in 2003.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Nike,_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "nike",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did Nike acquire Zodiac?",
+    "answer": "2018",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Nike,_Inc.",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/shopify.json
+++ b/data/generated/trivia/shopify.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "shopify",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Shopify founded?",
+    "answer": "2006",
+    "options": [
+      "2001",
+      "2004",
+      "2009"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Shopify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "shopify",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Shopify?",
+    "answer": "Tobias Lütke and Daniel Weinand and others",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Shopify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "shopify",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Shopify was founded in 2006 by Tobias Lütke and Daniel Weinand and others.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Shopify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "shopify",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Shopify's headquarters located?",
+    "answer": "Ottawa, Ontario, Canada",
+    "options": [
+      "Seattle, Washington",
+      "San Francisco, California",
+      "New York, New York"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Shopify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "shopify",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Shopify headquartered in?",
+    "answer": "Ottawa, Ontario, Canada",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Shopify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "shopify",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Shopify?",
+    "answer": "Tobias Lütke",
+    "options": [
+      "Josh Silverman",
+      "Brian Cornell",
+      "Doug McMillon"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Shopify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "shopify",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Shopify as CEO?",
+    "answer": "Tobias Lütke",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Shopify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "shopify",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Shopify's mission is \"To make commerce better for everyone\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Shopify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "shopify",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Shopify's mission statement?",
+    "answer": "To make commerce better for everyone",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Shopify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "shopify",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Shopify product or service?",
+    "answer": "E-commerce Platform",
+    "options": [
+      "Warehouse Clubs",
+      "Consumer Electronics",
+      "Athletic Footwear"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Shopify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "shopify",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Shopify offers E-commerce Platform, Shopify POS, Shopify Payments, Shop Pay.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Shopify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "shopify",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Shopify acquire in 2022?",
+    "answer": "Deliverr",
+    "options": [
+      "6 River Systems",
+      "Oberlo",
+      "Depop"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Shopify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "shopify",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Shopify acquired Deliverr in 2022.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Shopify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "shopify",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did Shopify acquire 6 River Systems?",
+    "answer": "2019",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Shopify",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/target.json
+++ b/data/generated/trivia/target.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "target",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Target founded?",
+    "answer": "1902",
+    "options": [
+      "1887",
+      "1894",
+      "1912"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Target_Corporation",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "target",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Target?",
+    "answer": "George Dayton",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Target_Corporation",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "target",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Target was founded in 1902 by George Dayton.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Target_Corporation",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "target",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Target's headquarters located?",
+    "answer": "Minneapolis, Minnesota",
+    "options": [
+      "Seattle, Washington",
+      "San Francisco, California",
+      "New York, New York"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Target_Corporation",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "target",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Target headquartered in?",
+    "answer": "Minneapolis, Minnesota",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Target_Corporation",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "target",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Target?",
+    "answer": "Brian Cornell",
+    "options": [
+      "Doug McMillon",
+      "Ron Vachris",
+      "Ted Decker"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Target_Corporation",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "target",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Target as CEO?",
+    "answer": "Brian Cornell",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Target_Corporation",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "target",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Target's mission is \"To help all families discover the joy of everyday life\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Target_Corporation",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "target",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Target's mission statement?",
+    "answer": "To help all families discover the joy of everyday life",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Target_Corporation",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "target",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Target product or service?",
+    "answer": "General Merchandise",
+    "options": [
+      "E-commerce Platform",
+      "Warehouse Clubs",
+      "Consumer Electronics"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Target_Corporation",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "target",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Target offers General Merchandise, Target Circle, Shipt Same-Day Delivery, Target RedCard.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Target_Corporation",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "target",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Target acquire in 2017?",
+    "answer": "Shipt",
+    "options": [
+      "Deliverr",
+      "6 River Systems",
+      "Oberlo"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Target_Corporation",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "target",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Target acquired Shipt in 2017.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Target_Corporation",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "target",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did Target acquire Grand Junction?",
+    "answer": "2017",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Target_Corporation",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/walmart.json
+++ b/data/generated/trivia/walmart.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "walmart",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Walmart founded?",
+    "answer": "1962",
+    "options": [
+      "1954",
+      "1958",
+      "1968"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Walmart",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "walmart",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Walmart?",
+    "answer": "Sam Walton",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Walmart",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "walmart",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Walmart was founded in 1962 by Sam Walton.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Walmart",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "walmart",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Walmart's headquarters located?",
+    "answer": "Bentonville, Arkansas",
+    "options": [
+      "Seattle, Washington",
+      "San Francisco, California",
+      "New York, New York"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Walmart",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "walmart",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Walmart headquartered in?",
+    "answer": "Bentonville, Arkansas",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Walmart",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "walmart",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Walmart?",
+    "answer": "Doug McMillon",
+    "options": [
+      "Brian Cornell",
+      "Ron Vachris",
+      "Ted Decker"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Walmart",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "walmart",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Walmart as CEO?",
+    "answer": "Doug McMillon",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Walmart",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "walmart",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Walmart's mission is \"To save people money so they can live better\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Walmart",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "walmart",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Walmart's mission statement?",
+    "answer": "To save people money so they can live better",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Walmart",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "walmart",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Walmart product or service?",
+    "answer": "Walmart Stores",
+    "options": [
+      "E-commerce Platform",
+      "Warehouse Clubs",
+      "Consumer Electronics"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Walmart",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "walmart",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Walmart offers Walmart Stores, Walmart.com, Sam's Club, Walmart+.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Walmart",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "walmart",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Walmart acquire in 2018?",
+    "answer": "Flipkart",
+    "options": [
+      "Deliverr",
+      "6 River Systems",
+      "Oberlo"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Walmart",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "walmart",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Walmart acquired Flipkart in 2018.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Walmart",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "walmart",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did Walmart acquire Jet.com?",
+    "answer": "2016",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Walmart",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/wayfair.json
+++ b/data/generated/trivia/wayfair.json
@@ -1,0 +1,152 @@
+[
+  {
+    "company_slug": "wayfair",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Wayfair founded?",
+    "answer": "2002",
+    "options": [
+      "1997",
+      "2000",
+      "2005"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Wayfair",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "wayfair",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Wayfair?",
+    "answer": "Niraj Shah and Steve Conine",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Wayfair",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "wayfair",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Wayfair was founded in 2002 by Niraj Shah and Steve Conine.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Wayfair",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "wayfair",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Wayfair's headquarters located?",
+    "answer": "Boston, Massachusetts",
+    "options": [
+      "Seattle, Washington",
+      "San Francisco, California",
+      "New York, New York"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Wayfair",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "wayfair",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Wayfair headquartered in?",
+    "answer": "Boston, Massachusetts",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Wayfair",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "wayfair",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Wayfair?",
+    "answer": "Niraj Shah",
+    "options": [
+      "Josh Silverman",
+      "Brian Cornell",
+      "Doug McMillon"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Wayfair",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "wayfair",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Wayfair as CEO?",
+    "answer": "Niraj Shah",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Wayfair",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "wayfair",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Wayfair's mission is \"To help everyone, anywhere, create their feeling of home\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Wayfair",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "wayfair",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Wayfair's mission statement?",
+    "answer": "To help everyone, anywhere, create their feeling of home",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Wayfair",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "wayfair",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Wayfair product or service?",
+    "answer": "Wayfair",
+    "options": [
+      "E-commerce Platform",
+      "Warehouse Clubs",
+      "Consumer Electronics"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Wayfair",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "wayfair",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Wayfair offers Wayfair, AllModern, Birch Lane, Joss & Main.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Wayfair",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "wayfair",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Wayfair acquire in 2012?",
+    "answer": "Linen Alley",
+    "options": [
+      "Deliverr",
+      "6 River Systems",
+      "Oberlo"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Wayfair",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "wayfair",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Wayfair acquired Linen Alley in 2012.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Wayfair",
+    "source_date": "2026-01-19"
+  }
+]

--- a/scripts/generate-trivia-ecommerce.ts
+++ b/scripts/generate-trivia-ecommerce.ts
@@ -1,0 +1,541 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Generate company trivia for E-commerce/Retail batch
+ * Issue #90
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Trivia item interface matching the Python generator
+interface TriviaItem {
+  company_slug: string;
+  fact_type: 'founding' | 'hq' | 'mission' | 'product' | 'news' | 'exec' | 'acquisition';
+  format: 'quiz' | 'flashcard' | 'factoid';
+  question: string | null;
+  answer: string;
+  options: string[] | null;
+  source_url: string | null;
+  source_date: string | null;
+}
+
+// E-commerce/Retail company data
+const ecommerceCompanies: Record<string, {
+  name: string;
+  foundingYear: string;
+  founders: string[];
+  hq: string;
+  ceo: string;
+  mission: string;
+  products: string[];
+  acquisitions: { name: string; year: string }[];
+  wikipedia: string;
+}> = {
+  shopify: {
+    name: 'Shopify',
+    foundingYear: '2006',
+    founders: ['Tobias Lütke', 'Daniel Weinand', 'Scott Lake'],
+    hq: 'Ottawa, Ontario, Canada',
+    ceo: 'Tobias Lütke',
+    mission: 'To make commerce better for everyone',
+    products: ['E-commerce Platform', 'Shopify POS', 'Shopify Payments', 'Shop Pay', 'Shopify Fulfillment Network'],
+    acquisitions: [
+      { name: 'Deliverr', year: '2022' },
+      { name: '6 River Systems', year: '2019' },
+      { name: 'Oberlo', year: '2017' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Shopify'
+  },
+  etsy: {
+    name: 'Etsy',
+    foundingYear: '2005',
+    founders: ['Rob Kalin', 'Chris Maguire', 'Haim Schoppik'],
+    hq: 'Brooklyn, New York',
+    ceo: 'Josh Silverman',
+    mission: 'To keep commerce human',
+    products: ['Etsy Marketplace', 'Etsy Payments', 'Etsy Ads', 'Pattern', 'Etsy Seller App'],
+    acquisitions: [
+      { name: 'Depop', year: '2021' },
+      { name: 'Elo7', year: '2021' },
+      { name: 'Reverb', year: '2019' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Etsy'
+  },
+  wayfair: {
+    name: 'Wayfair',
+    foundingYear: '2002',
+    founders: ['Niraj Shah', 'Steve Conine'],
+    hq: 'Boston, Massachusetts',
+    ceo: 'Niraj Shah',
+    mission: 'To help everyone, anywhere, create their feeling of home',
+    products: ['Wayfair', 'AllModern', 'Birch Lane', 'Joss & Main', 'Perigold'],
+    acquisitions: [
+      { name: 'Linen Alley', year: '2012' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Wayfair'
+  },
+  chewy: {
+    name: 'Chewy',
+    foundingYear: '2011',
+    founders: ['Ryan Cohen', 'Michael Day'],
+    hq: 'Dania Beach, Florida',
+    ceo: 'Sumit Singh',
+    mission: 'To be the most trusted and convenient destination for pet parents',
+    products: ['Pet Food', 'Pet Supplies', 'Chewy Pharmacy', 'Autoship Subscriptions', 'Connect with a Vet'],
+    acquisitions: [],
+    wikipedia: 'https://en.wikipedia.org/wiki/Chewy_(company)'
+  },
+  target: {
+    name: 'Target',
+    foundingYear: '1902',
+    founders: ['George Dayton'],
+    hq: 'Minneapolis, Minnesota',
+    ceo: 'Brian Cornell',
+    mission: 'To help all families discover the joy of everyday life',
+    products: ['General Merchandise', 'Target Circle', 'Shipt Same-Day Delivery', 'Target RedCard', 'Drive Up'],
+    acquisitions: [
+      { name: 'Shipt', year: '2017' },
+      { name: 'Grand Junction', year: '2017' },
+      { name: 'Deliv', year: '2020' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Target_Corporation'
+  },
+  walmart: {
+    name: 'Walmart',
+    foundingYear: '1962',
+    founders: ['Sam Walton'],
+    hq: 'Bentonville, Arkansas',
+    ceo: 'Doug McMillon',
+    mission: 'To save people money so they can live better',
+    products: ['Walmart Stores', 'Walmart.com', "Sam's Club", 'Walmart+', 'Walmart Health'],
+    acquisitions: [
+      { name: 'Flipkart', year: '2018' },
+      { name: 'Jet.com', year: '2016' },
+      { name: 'Bonobos', year: '2017' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Walmart'
+  },
+  costco: {
+    name: 'Costco',
+    foundingYear: '1983',
+    founders: ['James Sinegal', 'Jeffrey Brotman'],
+    hq: 'Issaquah, Washington',
+    ceo: 'Ron Vachris',
+    mission: 'To continually provide our members with quality goods and services at the lowest possible prices',
+    products: ['Warehouse Clubs', 'Kirkland Signature', 'Costco Travel', 'Costco Wholesale', 'Costco Pharmacy'],
+    acquisitions: [
+      { name: 'Price Club', year: '1993' },
+      { name: 'Innovel Solutions', year: '2020' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Costco'
+  },
+  'home-depot': {
+    name: 'The Home Depot',
+    foundingYear: '1978',
+    founders: ['Bernie Marcus', 'Arthur Blank', 'Ron Brill', 'Pat Farrah'],
+    hq: 'Atlanta, Georgia',
+    ceo: 'Ted Decker',
+    mission: 'To provide the highest level of service, the broadest selection of products, and the most competitive prices',
+    products: ['Home Improvement', 'Pro Services', 'Tool Rental', 'Installation Services', 'Home Depot Rental'],
+    acquisitions: [
+      { name: 'HD Supply', year: '2020' },
+      { name: 'Interline Brands', year: '2015' },
+      { name: 'Blinds.com', year: '2014' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/The_Home_Depot'
+  },
+  'best-buy': {
+    name: 'Best Buy',
+    foundingYear: '1966',
+    founders: ['Richard Schulze'],
+    hq: 'Richfield, Minnesota',
+    ceo: 'Corie Barry',
+    mission: 'To enrich lives through technology',
+    products: ['Consumer Electronics', 'Geek Squad', 'Best Buy Business', 'Best Buy Health', 'Totaltech Membership'],
+    acquisitions: [
+      { name: 'GreatCall', year: '2018' },
+      { name: 'Critical Signal Technologies', year: '2019' },
+      { name: 'Current Health', year: '2021' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Best_Buy'
+  },
+  nike: {
+    name: 'Nike',
+    foundingYear: '1964',
+    founders: ['Bill Bowerman', 'Phil Knight'],
+    hq: 'Beaverton, Oregon',
+    ceo: 'Elliott Hill',
+    mission: 'To bring inspiration and innovation to every athlete in the world',
+    products: ['Athletic Footwear', 'Athletic Apparel', 'Nike+', 'Air Jordan', 'Converse'],
+    acquisitions: [
+      { name: 'Converse', year: '2003' },
+      { name: 'Zodiac', year: '2018' },
+      { name: 'Datalogue', year: '2021' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Nike,_Inc.'
+  },
+  lululemon: {
+    name: 'Lululemon',
+    foundingYear: '1998',
+    founders: ['Chip Wilson'],
+    hq: 'Vancouver, British Columbia, Canada',
+    ceo: 'Calvin McDonald',
+    mission: 'To elevate human potential by helping people feel their best',
+    products: ['Athletic Apparel', 'Yoga Wear', 'Running Gear', 'Accessories', 'Mirror Home Gym'],
+    acquisitions: [
+      { name: 'Mirror', year: '2020' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Lululemon_Athletica'
+  }
+};
+
+function generateFoundingTrivia(slug: string, company: typeof ecommerceCompanies[string]): TriviaItem[] {
+  const items: TriviaItem[] = [];
+  const sourceDate = new Date().toISOString().split('T')[0] ?? null;
+
+  // Quiz: Founding year
+  items.push({
+    company_slug: slug,
+    fact_type: 'founding',
+    format: 'quiz',
+    question: `When was ${company.name} founded?`,
+    answer: company.foundingYear,
+    options: generateYearOptions(company.foundingYear),
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Flashcard: Founders
+  const foundersList = company.founders.length > 2
+    ? company.founders.slice(0, 2).join(' and ') + ' and others'
+    : company.founders.join(' and ');
+  items.push({
+    company_slug: slug,
+    fact_type: 'founding',
+    format: 'flashcard',
+    question: `Who founded ${company.name}?`,
+    answer: foundersList,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Factoid
+  items.push({
+    company_slug: slug,
+    fact_type: 'founding',
+    format: 'factoid',
+    question: null,
+    answer: `${company.name} was founded in ${company.foundingYear} by ${foundersList}.`,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  return items;
+}
+
+function generateHqTrivia(slug: string, company: typeof ecommerceCompanies[string]): TriviaItem[] {
+  const items: TriviaItem[] = [];
+  const sourceDate = new Date().toISOString().split('T')[0] ?? null;
+
+  // Quiz: Headquarters
+  items.push({
+    company_slug: slug,
+    fact_type: 'hq',
+    format: 'quiz',
+    question: `Where is ${company.name}'s headquarters located?`,
+    answer: company.hq,
+    options: generateHqOptions(company.hq),
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Flashcard
+  items.push({
+    company_slug: slug,
+    fact_type: 'hq',
+    format: 'flashcard',
+    question: `What city is ${company.name} headquartered in?`,
+    answer: company.hq,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  return items;
+}
+
+function generateExecTrivia(slug: string, company: typeof ecommerceCompanies[string]): TriviaItem[] {
+  const items: TriviaItem[] = [];
+  const sourceDate = new Date().toISOString().split('T')[0] ?? null;
+
+  // Quiz: CEO
+  items.push({
+    company_slug: slug,
+    fact_type: 'exec',
+    format: 'quiz',
+    question: `Who is the current CEO of ${company.name}?`,
+    answer: company.ceo,
+    options: generateCeoOptions(company.ceo, slug),
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Flashcard
+  items.push({
+    company_slug: slug,
+    fact_type: 'exec',
+    format: 'flashcard',
+    question: `Who leads ${company.name} as CEO?`,
+    answer: company.ceo,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  return items;
+}
+
+function generateMissionTrivia(slug: string, company: typeof ecommerceCompanies[string]): TriviaItem[] {
+  const items: TriviaItem[] = [];
+  const sourceDate = new Date().toISOString().split('T')[0] ?? null;
+
+  // Factoid: Mission
+  items.push({
+    company_slug: slug,
+    fact_type: 'mission',
+    format: 'factoid',
+    question: null,
+    answer: `${company.name}'s mission is "${company.mission}".`,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Flashcard
+  items.push({
+    company_slug: slug,
+    fact_type: 'mission',
+    format: 'flashcard',
+    question: `What is ${company.name}'s mission statement?`,
+    answer: company.mission,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  return items;
+}
+
+function generateProductTrivia(slug: string, company: typeof ecommerceCompanies[string]): TriviaItem[] {
+  const items: TriviaItem[] = [];
+  const sourceDate = new Date().toISOString().split('T')[0] ?? null;
+
+  // Quiz: Products
+  const mainProduct = company.products[0];
+  items.push({
+    company_slug: slug,
+    fact_type: 'product',
+    format: 'quiz',
+    question: `Which of these is a ${company.name} product or service?`,
+    answer: mainProduct!,
+    options: generateProductOptions(mainProduct!, slug),
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Factoid: Products list
+  const productsList = company.products.slice(0, 4).join(', ');
+  items.push({
+    company_slug: slug,
+    fact_type: 'product',
+    format: 'factoid',
+    question: null,
+    answer: `${company.name} offers ${productsList}.`,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  return items;
+}
+
+function generateAcquisitionTrivia(slug: string, company: typeof ecommerceCompanies[string]): TriviaItem[] {
+  const items: TriviaItem[] = [];
+  const sourceDate = new Date().toISOString().split('T')[0] ?? null;
+
+  if (company.acquisitions.length === 0) return items;
+
+  // Quiz: Notable acquisition
+  const mainAcquisition = company.acquisitions[0];
+  items.push({
+    company_slug: slug,
+    fact_type: 'acquisition',
+    format: 'quiz',
+    question: `Which company did ${company.name} acquire in ${mainAcquisition!.year}?`,
+    answer: mainAcquisition!.name,
+    options: generateAcquisitionOptions(mainAcquisition!.name),
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Factoid
+  items.push({
+    company_slug: slug,
+    fact_type: 'acquisition',
+    format: 'factoid',
+    question: null,
+    answer: `${company.name} acquired ${mainAcquisition!.name} in ${mainAcquisition!.year}.`,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Additional acquisition if available
+  if (company.acquisitions.length > 1) {
+    const secondAcquisition = company.acquisitions[1];
+    items.push({
+      company_slug: slug,
+      fact_type: 'acquisition',
+      format: 'flashcard',
+      question: `In what year did ${company.name} acquire ${secondAcquisition!.name}?`,
+      answer: secondAcquisition!.year,
+      options: null,
+      source_url: company.wikipedia,
+      source_date: sourceDate
+    });
+  }
+
+  return items;
+}
+
+function generateYearOptions(correctYear: string): string[] {
+  const year = parseInt(correctYear);
+  const options: string[] = [];
+  // For older companies (before 1950), use larger offsets
+  if (year < 1950) {
+    const offsets = [-15, -8, 10];
+    for (const offset of offsets) {
+      options.push((year + offset).toString());
+    }
+  } else if (year < 1980) {
+    const offsets = [-8, -4, 6];
+    for (const offset of offsets) {
+      options.push((year + offset).toString());
+    }
+  } else {
+    const offsets = [-5, -2, 3];
+    for (const offset of offsets) {
+      options.push((year + offset).toString());
+    }
+  }
+  return options;
+}
+
+function generateHqOptions(correctHq: string): string[] {
+  const hqOptions = [
+    'Seattle, Washington',
+    'San Francisco, California',
+    'New York, New York',
+    'Austin, Texas',
+    'Boston, Massachusetts',
+    'Chicago, Illinois',
+    'Los Angeles, California',
+    'Atlanta, Georgia',
+    'Minneapolis, Minnesota',
+    'Ottawa, Ontario, Canada',
+    'Vancouver, British Columbia, Canada',
+    'Brooklyn, New York',
+    'Bentonville, Arkansas',
+    'Issaquah, Washington',
+    'Beaverton, Oregon',
+    'Richfield, Minnesota',
+    'Dania Beach, Florida'
+  ];
+  return hqOptions.filter(hq => hq !== correctHq).slice(0, 3);
+}
+
+function generateCeoOptions(correctCeo: string, companySlug: string): string[] {
+  const ceoOptions: Record<string, string[]> = {
+    shopify: ['Josh Silverman', 'Brian Cornell', 'Doug McMillon'],
+    etsy: ['Tobias Lütke', 'Brian Cornell', 'Doug McMillon'],
+    wayfair: ['Josh Silverman', 'Brian Cornell', 'Doug McMillon'],
+    chewy: ['Niraj Shah', 'Josh Silverman', 'Brian Cornell'],
+    target: ['Doug McMillon', 'Ron Vachris', 'Ted Decker'],
+    walmart: ['Brian Cornell', 'Ron Vachris', 'Ted Decker'],
+    costco: ['Doug McMillon', 'Brian Cornell', 'Ted Decker'],
+    'home-depot': ['Doug McMillon', 'Brian Cornell', 'Ron Vachris'],
+    'best-buy': ['Doug McMillon', 'Brian Cornell', 'Ted Decker'],
+    nike: ['Doug McMillon', 'Calvin McDonald', 'Brian Cornell'],
+    lululemon: ['Elliott Hill', 'Doug McMillon', 'Brian Cornell']
+  };
+  return ceoOptions[companySlug] || ['Doug McMillon', 'Brian Cornell', 'Ted Decker'];
+}
+
+function generateProductOptions(correctProduct: string, companySlug: string): string[] {
+  const allProducts = [
+    'E-commerce Platform', 'Warehouse Clubs', 'Consumer Electronics',
+    'Athletic Footwear', 'Home Improvement', 'Pet Food',
+    'General Merchandise', 'Yoga Wear', 'Handmade Marketplace',
+    'Furniture', 'Tool Rental', 'Geek Squad',
+    'Kirkland Signature', 'Air Jordan', 'Mirror Home Gym',
+    'Drive Up', 'Autoship Subscriptions', 'Shipt Same-Day Delivery'
+  ];
+  return allProducts.filter(p => p !== correctProduct).slice(0, 3);
+}
+
+function generateAcquisitionOptions(correctAcquisition: string): string[] {
+  const acquisitionOptions = [
+    'Deliverr', '6 River Systems', 'Oberlo', 'Depop', 'Elo7',
+    'Reverb', 'Shipt', 'Flipkart', 'Jet.com', 'Bonobos',
+    'Price Club', 'HD Supply', 'Interline Brands', 'GreatCall',
+    'Mirror', 'Converse', 'Zodiac', 'Current Health'
+  ];
+  return acquisitionOptions.filter(a => a !== correctAcquisition).slice(0, 3);
+}
+
+function generateCompanyTrivia(slug: string): TriviaItem[] {
+  const company = ecommerceCompanies[slug];
+  if (!company) {
+    console.warn(`No data for company: ${slug}`);
+    return [];
+  }
+
+  const items: TriviaItem[] = [
+    ...generateFoundingTrivia(slug, company),
+    ...generateHqTrivia(slug, company),
+    ...generateExecTrivia(slug, company),
+    ...generateMissionTrivia(slug, company),
+    ...generateProductTrivia(slug, company),
+    ...generateAcquisitionTrivia(slug, company)
+  ];
+
+  return items;
+}
+
+function main() {
+  const outputDir = path.join(process.cwd(), 'data', 'generated', 'trivia');
+
+  // Ensure output directory exists
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  const slugs = Object.keys(ecommerceCompanies);
+  let totalItems = 0;
+
+  for (const slug of slugs) {
+    const items = generateCompanyTrivia(slug);
+    const outputPath = path.join(outputDir, `${slug}.json`);
+
+    fs.writeFileSync(outputPath, JSON.stringify(items, null, 2));
+    console.log(`Generated ${items.length} trivia items for ${slug}`);
+    totalItems += items.length;
+  }
+
+  console.log(`\nTotal: ${totalItems} trivia items for ${slugs.length} E-commerce/Retail companies`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- Created trivia generation script for E-commerce/Retail batch
- Generated trivia for 11 companies: Shopify, Etsy, Wayfair, Chewy, Target, Walmart, Costco, Home Depot, Best Buy, Nike, Lululemon
- Generated 149 trivia items total (11-14 items per company)

## Test plan
- [x] Run `npm run lint` - passes
- [x] Run `npm run type-check` - passes
- [x] Run `npm run build` - passes
- [x] Run `npm test` - 2163 passed, 12 pre-existing failures unrelated to this change
- [x] Verify all trivia files created in `data/generated/trivia/`
- [x] Verify quiz items have exactly 3 wrong options
- [x] Verify all items have source_url and source_date

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)