### PR TITLE
Generate company trivia for Media/Entertainment batch (#93)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -3238,3 +3238,55 @@ All Stage 5 (Launch) code issues are now closed:
 - Quiz items have exactly 3 wrong options
 - All items have source_url and source_date
 
+### 2026-01-19 - Issue #93: Generate company trivia: Media/Entertainment batch
+
+**Completed:**
+- Created trivia generation script `/scripts/generate-trivia-media-entertainment.ts`
+- Generated trivia for 11 Media/Entertainment companies:
+  - Disney, Warner Bros. Discovery, Spotify, ByteDance (TikTok)
+  - Snap, Pinterest, Reddit, LinkedIn
+  - X (formerly Twitter), Electronic Arts (EA), Activision Blizzard
+- Generated 154 trivia items total (14 items per company)
+- Output files in `/data/generated/trivia/{company}.json`
+
+**Trivia Types Generated:**
+- Founding (quiz, flashcard, factoid)
+- Headquarters (quiz, flashcard)
+- CEO/Executive (quiz, flashcard)
+- Mission statement (factoid, flashcard)
+- Products (quiz, factoid)
+- Acquisitions (quiz, factoid, flashcard)
+
+**Format per Item:**
+- `company_slug` - company identifier
+- `fact_type` - founding, hq, mission, product, news, exec, acquisition
+- `format` - quiz, flashcard, factoid
+- `question` - question text (null for factoids)
+- `answer` - correct answer
+- `options` - 3 wrong answers (for quiz format only)
+- `source_url` - Wikipedia source link
+- `source_date` - date of generation
+
+**Files Created:**
+- `scripts/generate-trivia-media-entertainment.ts` - trivia generation script
+- `data/generated/trivia/disney.json` (14 items)
+- `data/generated/trivia/warner-bros-discovery.json` (14 items)
+- `data/generated/trivia/spotify.json` (14 items)
+- `data/generated/trivia/bytedance.json` (14 items)
+- `data/generated/trivia/snap.json` (14 items)
+- `data/generated/trivia/pinterest.json` (14 items)
+- `data/generated/trivia/reddit.json` (14 items)
+- `data/generated/trivia/linkedin.json` (14 items)
+- `data/generated/trivia/x.json` (14 items)
+- `data/generated/trivia/ea.json` (14 items)
+- `data/generated/trivia/activision-blizzard.json` (14 items)
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - 2163 passed, 2 todo, 12 pre-existing failures (unrelated to this change)
+- All trivia files conform to expected schema
+- Quiz items have exactly 3 wrong options
+- All items have source_url and source_date
+

--- a/data/generated/trivia/activision-blizzard.json
+++ b/data/generated/trivia/activision-blizzard.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "activision-blizzard",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Activision Blizzard founded?",
+    "answer": "2008",
+    "options": [
+      "2003",
+      "2006",
+      "2011"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Activision_Blizzard",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "activision-blizzard",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Activision Blizzard?",
+    "answer": "Formed from merger of Activision and Vivendi Games",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Activision_Blizzard",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "activision-blizzard",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Activision Blizzard was founded in 2008 by Formed from merger of Activision and Vivendi Games.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Activision_Blizzard",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "activision-blizzard",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Activision Blizzard's headquarters located?",
+    "answer": "Santa Monica, California",
+    "options": [
+      "San Francisco, California",
+      "New York, New York",
+      "Los Angeles, California"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Activision_Blizzard",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "activision-blizzard",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Activision Blizzard headquartered in?",
+    "answer": "Santa Monica, California",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Activision_Blizzard",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "activision-blizzard",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Activision Blizzard?",
+    "answer": "Bobby Kotick (until acquisition)",
+    "options": [
+      "Andrew Wilson",
+      "Phil Spencer",
+      "Jim Ryan"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Activision_Blizzard",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "activision-blizzard",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Activision Blizzard as CEO?",
+    "answer": "Bobby Kotick (until acquisition)",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Activision_Blizzard",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "activision-blizzard",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Activision Blizzard's mission is \"To connect and engage the world through epic entertainment\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Activision_Blizzard",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "activision-blizzard",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Activision Blizzard's mission statement?",
+    "answer": "To connect and engage the world through epic entertainment",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Activision_Blizzard",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "activision-blizzard",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Activision Blizzard product or service?",
+    "answer": "Call of Duty",
+    "options": [
+      "Netflix",
+      "Hulu",
+      "Amazon Prime Video"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Activision_Blizzard",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "activision-blizzard",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Key Activision Blizzard products and services include Call of Duty, World of Warcraft, Overwatch, Candy Crush, Diablo.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Activision_Blizzard",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "activision-blizzard",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Activision Blizzard acquire in 2016?",
+    "answer": "King Digital Entertainment",
+    "options": [
+      "Lucasfilm",
+      "Marvel",
+      "Pixar"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Activision_Blizzard",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "activision-blizzard",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Activision Blizzard acquired King Digital Entertainment in 2016.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Activision_Blizzard",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "activision-blizzard",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did Activision Blizzard acquire Major League Gaming?",
+    "answer": "2016",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Activision_Blizzard",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/bytedance.json
+++ b/data/generated/trivia/bytedance.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "bytedance",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was ByteDance founded?",
+    "answer": "2012",
+    "options": [
+      "2007",
+      "2010",
+      "2015"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/ByteDance",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "bytedance",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded ByteDance?",
+    "answer": "Zhang Yiming",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/ByteDance",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "bytedance",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "ByteDance was founded in 2012 by Zhang Yiming.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/ByteDance",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "bytedance",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is ByteDance's headquarters located?",
+    "answer": "Beijing, China",
+    "options": [
+      "San Francisco, California",
+      "New York, New York",
+      "Los Angeles, California"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/ByteDance",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "bytedance",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is ByteDance headquartered in?",
+    "answer": "Beijing, China",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/ByteDance",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "bytedance",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of ByteDance?",
+    "answer": "Liang Rubo",
+    "options": [
+      "Daniel Ek",
+      "Mark Zuckerberg",
+      "Evan Spiegel"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/ByteDance",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "bytedance",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads ByteDance as CEO?",
+    "answer": "Liang Rubo",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/ByteDance",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "bytedance",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "ByteDance's mission is \"To inspire creativity and bring joy\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/ByteDance",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "bytedance",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is ByteDance's mission statement?",
+    "answer": "To inspire creativity and bring joy",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/ByteDance",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "bytedance",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a ByteDance product or service?",
+    "answer": "TikTok",
+    "options": [
+      "Netflix",
+      "Hulu",
+      "Amazon Prime Video"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/ByteDance",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "bytedance",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Key ByteDance products and services include TikTok, Douyin, Toutiao, CapCut, Lark.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/ByteDance",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "bytedance",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did ByteDance acquire in 2017?",
+    "answer": "Musical.ly",
+    "options": [
+      "Lucasfilm",
+      "Marvel",
+      "Pixar"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/ByteDance",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "bytedance",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "ByteDance acquired Musical.ly in 2017.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/ByteDance",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "bytedance",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did ByteDance acquire Pico?",
+    "answer": "2021",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/ByteDance",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/disney.json
+++ b/data/generated/trivia/disney.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "disney",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Disney founded?",
+    "answer": "1923",
+    "options": [
+      "1915",
+      "1919",
+      "1928"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/The_Walt_Disney_Company",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "disney",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Disney?",
+    "answer": "Walt Disney and Roy O. Disney",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Walt_Disney_Company",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "disney",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Disney was founded in 1923 by Walt Disney and Roy O. Disney.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Walt_Disney_Company",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "disney",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Disney's headquarters located?",
+    "answer": "Burbank, California",
+    "options": [
+      "San Francisco, California",
+      "New York, New York",
+      "Los Angeles, California"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/The_Walt_Disney_Company",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "disney",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Disney headquartered in?",
+    "answer": "Burbank, California",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Walt_Disney_Company",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "disney",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Disney?",
+    "answer": "Bob Iger",
+    "options": [
+      "David Zaslav",
+      "Reed Hastings",
+      "Tim Cook"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/The_Walt_Disney_Company",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "disney",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Disney as CEO?",
+    "answer": "Bob Iger",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Walt_Disney_Company",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "disney",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Disney's mission is \"To entertain, inform and inspire people around the globe through the power of unparalleled storytelling\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Walt_Disney_Company",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "disney",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Disney's mission statement?",
+    "answer": "To entertain, inform and inspire people around the globe through the power of unparalleled storytelling",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Walt_Disney_Company",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "disney",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Disney product or service?",
+    "answer": "Disney+",
+    "options": [
+      "Netflix",
+      "Hulu",
+      "Amazon Prime Video"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/The_Walt_Disney_Company",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "disney",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Key Disney products and services include Disney+, Walt Disney Studios, Pixar, Marvel Studios, Lucasfilm.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Walt_Disney_Company",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "disney",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Disney acquire in 2019?",
+    "answer": "21st Century Fox",
+    "options": [
+      "Lucasfilm",
+      "Marvel",
+      "Pixar"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/The_Walt_Disney_Company",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "disney",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Disney acquired 21st Century Fox in 2019.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Walt_Disney_Company",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "disney",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did Disney acquire Lucasfilm?",
+    "answer": "2012",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/The_Walt_Disney_Company",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/ea.json
+++ b/data/generated/trivia/ea.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "ea",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Electronic Arts (EA) founded?",
+    "answer": "1982",
+    "options": [
+      "1974",
+      "1978",
+      "1987"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Electronic_Arts",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "ea",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Electronic Arts (EA)?",
+    "answer": "Trip Hawkins",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Electronic_Arts",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "ea",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Electronic Arts (EA) was founded in 1982 by Trip Hawkins.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Electronic_Arts",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "ea",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Electronic Arts (EA)'s headquarters located?",
+    "answer": "Redwood City, California",
+    "options": [
+      "San Francisco, California",
+      "New York, New York",
+      "Los Angeles, California"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Electronic_Arts",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "ea",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Electronic Arts (EA) headquartered in?",
+    "answer": "Redwood City, California",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Electronic_Arts",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "ea",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Electronic Arts (EA)?",
+    "answer": "Andrew Wilson",
+    "options": [
+      "Bobby Kotick",
+      "Phil Spencer",
+      "Satya Nadella"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Electronic_Arts",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "ea",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Electronic Arts (EA) as CEO?",
+    "answer": "Andrew Wilson",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Electronic_Arts",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "ea",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Electronic Arts (EA)'s mission is \"To inspire the world to play\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Electronic_Arts",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "ea",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Electronic Arts (EA)'s mission statement?",
+    "answer": "To inspire the world to play",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Electronic_Arts",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "ea",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Electronic Arts (EA) product or service?",
+    "answer": "EA Sports FC",
+    "options": [
+      "Netflix",
+      "Hulu",
+      "Amazon Prime Video"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Electronic_Arts",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "ea",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Key Electronic Arts (EA) products and services include EA Sports FC, Madden NFL, The Sims, Apex Legends, Battlefield.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Electronic_Arts",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "ea",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Electronic Arts (EA) acquire in 2017?",
+    "answer": "Respawn Entertainment",
+    "options": [
+      "Lucasfilm",
+      "Marvel",
+      "Pixar"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Electronic_Arts",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "ea",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Electronic Arts (EA) acquired Respawn Entertainment in 2017.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Electronic_Arts",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "ea",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did Electronic Arts (EA) acquire Codemasters?",
+    "answer": "2021",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Electronic_Arts",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/linkedin.json
+++ b/data/generated/trivia/linkedin.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "linkedin",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was LinkedIn founded?",
+    "answer": "2002",
+    "options": [
+      "1997",
+      "2000",
+      "2005"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/LinkedIn",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "linkedin",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded LinkedIn?",
+    "answer": "Reid Hoffman and Allen Blue and others",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/LinkedIn",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "linkedin",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "LinkedIn was founded in 2002 by Reid Hoffman and Allen Blue and others.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/LinkedIn",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "linkedin",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is LinkedIn's headquarters located?",
+    "answer": "Sunnyvale, California",
+    "options": [
+      "San Francisco, California",
+      "New York, New York",
+      "Los Angeles, California"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/LinkedIn",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "linkedin",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is LinkedIn headquartered in?",
+    "answer": "Sunnyvale, California",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/LinkedIn",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "linkedin",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of LinkedIn?",
+    "answer": "Ryan Roslansky",
+    "options": [
+      "Mark Zuckerberg",
+      "Steve Huffman",
+      "Jeff Weiner"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/LinkedIn",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "linkedin",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads LinkedIn as CEO?",
+    "answer": "Ryan Roslansky",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/LinkedIn",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "linkedin",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "LinkedIn's mission is \"To connect the world's professionals to make them more productive and successful\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/LinkedIn",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "linkedin",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is LinkedIn's mission statement?",
+    "answer": "To connect the world's professionals to make them more productive and successful",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/LinkedIn",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "linkedin",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a LinkedIn product or service?",
+    "answer": "LinkedIn",
+    "options": [
+      "Netflix",
+      "Hulu",
+      "Amazon Prime Video"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/LinkedIn",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "linkedin",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Key LinkedIn products and services include LinkedIn, LinkedIn Learning, LinkedIn Premium, LinkedIn Recruiter, LinkedIn Sales Navigator.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/LinkedIn",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "linkedin",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did LinkedIn acquire in 2015?",
+    "answer": "Lynda.com",
+    "options": [
+      "Lucasfilm",
+      "Marvel",
+      "Pixar"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/LinkedIn",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "linkedin",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "LinkedIn acquired Lynda.com in 2015.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/LinkedIn",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "linkedin",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did LinkedIn acquire SlideShare?",
+    "answer": "2012",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/LinkedIn",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/pinterest.json
+++ b/data/generated/trivia/pinterest.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "pinterest",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Pinterest founded?",
+    "answer": "2010",
+    "options": [
+      "2005",
+      "2008",
+      "2013"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Pinterest",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "pinterest",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Pinterest?",
+    "answer": "Ben Silbermann and Paul Sciarra and others",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Pinterest",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "pinterest",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Pinterest was founded in 2010 by Ben Silbermann and Paul Sciarra and others.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Pinterest",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "pinterest",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Pinterest's headquarters located?",
+    "answer": "San Francisco, California",
+    "options": [
+      "New York, New York",
+      "Los Angeles, California",
+      "Seattle, Washington"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Pinterest",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "pinterest",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Pinterest headquartered in?",
+    "answer": "San Francisco, California",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Pinterest",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "pinterest",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Pinterest?",
+    "answer": "Bill Ready",
+    "options": [
+      "Evan Spiegel",
+      "Steve Huffman",
+      "Mark Zuckerberg"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Pinterest",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "pinterest",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Pinterest as CEO?",
+    "answer": "Bill Ready",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Pinterest",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "pinterest",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Pinterest's mission is \"To bring everyone the inspiration to create a life they love\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Pinterest",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "pinterest",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Pinterest's mission statement?",
+    "answer": "To bring everyone the inspiration to create a life they love",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Pinterest",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "pinterest",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Pinterest product or service?",
+    "answer": "Pinterest",
+    "options": [
+      "Netflix",
+      "Hulu",
+      "Amazon Prime Video"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Pinterest",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "pinterest",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Key Pinterest products and services include Pinterest, Pinterest Lens, Pinterest Shopping, Idea Pins, Pinterest TV.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Pinterest",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "pinterest",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Pinterest acquire in 2022?",
+    "answer": "THE YES",
+    "options": [
+      "Lucasfilm",
+      "Marvel",
+      "Pixar"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Pinterest",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "pinterest",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Pinterest acquired THE YES in 2022.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Pinterest",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "pinterest",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did Pinterest acquire Vochi?",
+    "answer": "2021",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Pinterest",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/reddit.json
+++ b/data/generated/trivia/reddit.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "reddit",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Reddit founded?",
+    "answer": "2005",
+    "options": [
+      "2000",
+      "2003",
+      "2008"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Reddit",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "reddit",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Reddit?",
+    "answer": "Steve Huffman and Alexis Ohanian",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Reddit",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "reddit",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Reddit was founded in 2005 by Steve Huffman and Alexis Ohanian.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Reddit",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "reddit",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Reddit's headquarters located?",
+    "answer": "San Francisco, California",
+    "options": [
+      "New York, New York",
+      "Los Angeles, California",
+      "Seattle, Washington"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Reddit",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "reddit",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Reddit headquartered in?",
+    "answer": "San Francisco, California",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Reddit",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "reddit",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Reddit?",
+    "answer": "Steve Huffman",
+    "options": [
+      "Ben Silbermann",
+      "Evan Spiegel",
+      "Jack Dorsey"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Reddit",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "reddit",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Reddit as CEO?",
+    "answer": "Steve Huffman",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Reddit",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "reddit",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Reddit's mission is \"To bring community, belonging, and empowerment to everyone in the world\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Reddit",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "reddit",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Reddit's mission statement?",
+    "answer": "To bring community, belonging, and empowerment to everyone in the world",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Reddit",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "reddit",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Reddit product or service?",
+    "answer": "Reddit",
+    "options": [
+      "Netflix",
+      "Hulu",
+      "Amazon Prime Video"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Reddit",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "reddit",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Key Reddit products and services include Reddit, Reddit Premium, Reddit Coins, Reddit Awards, Reddit Chat.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Reddit",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "reddit",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Reddit acquire in 2020?",
+    "answer": "Dubsmash",
+    "options": [
+      "Lucasfilm",
+      "Marvel",
+      "Pixar"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Reddit",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "reddit",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Reddit acquired Dubsmash in 2020.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Reddit",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "reddit",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did Reddit acquire Spiketrap?",
+    "answer": "2022",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Reddit",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/snap.json
+++ b/data/generated/trivia/snap.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "snap",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Snap Inc. founded?",
+    "answer": "2011",
+    "options": [
+      "2006",
+      "2009",
+      "2014"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Snap_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "snap",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Snap Inc.?",
+    "answer": "Evan Spiegel and Bobby Murphy and others",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Snap_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "snap",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Snap Inc. was founded in 2011 by Evan Spiegel and Bobby Murphy and others.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Snap_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "snap",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Snap Inc.'s headquarters located?",
+    "answer": "Santa Monica, California",
+    "options": [
+      "San Francisco, California",
+      "New York, New York",
+      "Los Angeles, California"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Snap_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "snap",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Snap Inc. headquartered in?",
+    "answer": "Santa Monica, California",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Snap_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "snap",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Snap Inc.?",
+    "answer": "Evan Spiegel",
+    "options": [
+      "Mark Zuckerberg",
+      "Ben Silbermann",
+      "Steve Huffman"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Snap_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "snap",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Snap Inc. as CEO?",
+    "answer": "Evan Spiegel",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Snap_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "snap",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Snap Inc.'s mission is \"To empower people to express themselves, live in the moment, learn about the world, and have fun together\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Snap_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "snap",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Snap Inc.'s mission statement?",
+    "answer": "To empower people to express themselves, live in the moment, learn about the world, and have fun together",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Snap_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "snap",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Snap Inc. product or service?",
+    "answer": "Snapchat",
+    "options": [
+      "Netflix",
+      "Hulu",
+      "Amazon Prime Video"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Snap_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "snap",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Key Snap Inc. products and services include Snapchat, Snap Map, Snap Spectacles, Bitmoji, Snap Camera.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Snap_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "snap",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Snap Inc. acquire in 2016?",
+    "answer": "Bitmoji",
+    "options": [
+      "Lucasfilm",
+      "Marvel",
+      "Pixar"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Snap_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "snap",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Snap Inc. acquired Bitmoji in 2016.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Snap_Inc.",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "snap",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did Snap Inc. acquire Zenly?",
+    "answer": "2017",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Snap_Inc.",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/spotify.json
+++ b/data/generated/trivia/spotify.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "spotify",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Spotify founded?",
+    "answer": "2006",
+    "options": [
+      "2001",
+      "2004",
+      "2009"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Spotify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "spotify",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Spotify?",
+    "answer": "Daniel Ek and Martin Lorentzon",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Spotify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "spotify",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Spotify was founded in 2006 by Daniel Ek and Martin Lorentzon.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Spotify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "spotify",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Spotify's headquarters located?",
+    "answer": "Stockholm, Sweden",
+    "options": [
+      "San Francisco, California",
+      "New York, New York",
+      "Los Angeles, California"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Spotify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "spotify",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Spotify headquartered in?",
+    "answer": "Stockholm, Sweden",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Spotify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "spotify",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Spotify?",
+    "answer": "Daniel Ek",
+    "options": [
+      "Reed Hastings",
+      "Evan Spiegel",
+      "Mark Zuckerberg"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Spotify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "spotify",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Spotify as CEO?",
+    "answer": "Daniel Ek",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Spotify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "spotify",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Spotify's mission is \"To unlock the potential of human creativity by giving a million creative artists the opportunity to live off their art\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Spotify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "spotify",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Spotify's mission statement?",
+    "answer": "To unlock the potential of human creativity by giving a million creative artists the opportunity to live off their art",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Spotify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "spotify",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Spotify product or service?",
+    "answer": "Spotify Free",
+    "options": [
+      "Netflix",
+      "Hulu",
+      "Amazon Prime Video"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Spotify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "spotify",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Key Spotify products and services include Spotify Free, Spotify Premium, Spotify for Artists, Spotify for Podcasters, Spotify Wrapped.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Spotify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "spotify",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Spotify acquire in 2019?",
+    "answer": "Anchor",
+    "options": [
+      "Lucasfilm",
+      "Marvel",
+      "Pixar"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Spotify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "spotify",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Spotify acquired Anchor in 2019.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Spotify",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "spotify",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did Spotify acquire Gimlet Media?",
+    "answer": "2019",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Spotify",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/warner-bros-discovery.json
+++ b/data/generated/trivia/warner-bros-discovery.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "warner-bros-discovery",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was Warner Bros. Discovery founded?",
+    "answer": "2022",
+    "options": [
+      "2017",
+      "2020",
+      "2025"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Warner_Bros._Discovery",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "warner-bros-discovery",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded Warner Bros. Discovery?",
+    "answer": "Formed from merger of WarnerMedia and Discovery, Inc.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Warner_Bros._Discovery",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "warner-bros-discovery",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "Warner Bros. Discovery was founded in 2022 by Formed from merger of WarnerMedia and Discovery, Inc..",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Warner_Bros._Discovery",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "warner-bros-discovery",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is Warner Bros. Discovery's headquarters located?",
+    "answer": "New York, New York",
+    "options": [
+      "San Francisco, California",
+      "Los Angeles, California",
+      "Seattle, Washington"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Warner_Bros._Discovery",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "warner-bros-discovery",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is Warner Bros. Discovery headquartered in?",
+    "answer": "New York, New York",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Warner_Bros._Discovery",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "warner-bros-discovery",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of Warner Bros. Discovery?",
+    "answer": "David Zaslav",
+    "options": [
+      "Bob Iger",
+      "Reed Hastings",
+      "Brian Roberts"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Warner_Bros._Discovery",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "warner-bros-discovery",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads Warner Bros. Discovery as CEO?",
+    "answer": "David Zaslav",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Warner_Bros._Discovery",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "warner-bros-discovery",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "Warner Bros. Discovery's mission is \"To be the preeminent global entertainment company\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Warner_Bros._Discovery",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "warner-bros-discovery",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is Warner Bros. Discovery's mission statement?",
+    "answer": "To be the preeminent global entertainment company",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Warner_Bros._Discovery",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "warner-bros-discovery",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a Warner Bros. Discovery product or service?",
+    "answer": "Max",
+    "options": [
+      "Netflix",
+      "Hulu",
+      "Amazon Prime Video"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Warner_Bros._Discovery",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "warner-bros-discovery",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Key Warner Bros. Discovery products and services include Max, HBO, Warner Bros. Pictures, Discovery Channel, CNN.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Warner_Bros._Discovery",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "warner-bros-discovery",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did Warner Bros. Discovery acquire in 2022?",
+    "answer": "WarnerMedia (merger)",
+    "options": [
+      "Lucasfilm",
+      "Marvel",
+      "Pixar"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/Warner_Bros._Discovery",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "warner-bros-discovery",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "Warner Bros. Discovery acquired WarnerMedia (merger) in 2022.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Warner_Bros._Discovery",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "warner-bros-discovery",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did Warner Bros. Discovery acquire Scripps Networks Interactive?",
+    "answer": "2018",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/Warner_Bros._Discovery",
+    "source_date": "2026-01-19"
+  }
+]

--- a/data/generated/trivia/x.json
+++ b/data/generated/trivia/x.json
@@ -1,0 +1,162 @@
+[
+  {
+    "company_slug": "x",
+    "fact_type": "founding",
+    "format": "quiz",
+    "question": "When was X (formerly Twitter) founded?",
+    "answer": "2006",
+    "options": [
+      "2001",
+      "2004",
+      "2009"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/X_(social_network)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "x",
+    "fact_type": "founding",
+    "format": "flashcard",
+    "question": "Who founded X (formerly Twitter)?",
+    "answer": "Jack Dorsey and Noah Glass and others",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/X_(social_network)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "x",
+    "fact_type": "founding",
+    "format": "factoid",
+    "question": null,
+    "answer": "X (formerly Twitter) was founded in 2006 by Jack Dorsey and Noah Glass and others.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/X_(social_network)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "x",
+    "fact_type": "hq",
+    "format": "quiz",
+    "question": "Where is X (formerly Twitter)'s headquarters located?",
+    "answer": "San Francisco, California",
+    "options": [
+      "New York, New York",
+      "Los Angeles, California",
+      "Seattle, Washington"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/X_(social_network)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "x",
+    "fact_type": "hq",
+    "format": "flashcard",
+    "question": "What city is X (formerly Twitter) headquartered in?",
+    "answer": "San Francisco, California",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/X_(social_network)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "x",
+    "fact_type": "exec",
+    "format": "quiz",
+    "question": "Who is the current CEO of X (formerly Twitter)?",
+    "answer": "Linda Yaccarino",
+    "options": [
+      "Elon Musk",
+      "Jack Dorsey",
+      "Mark Zuckerberg"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/X_(social_network)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "x",
+    "fact_type": "exec",
+    "format": "flashcard",
+    "question": "Who leads X (formerly Twitter) as CEO?",
+    "answer": "Linda Yaccarino",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/X_(social_network)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "x",
+    "fact_type": "mission",
+    "format": "factoid",
+    "question": null,
+    "answer": "X (formerly Twitter)'s mission is \"To give everyone the power to create and share ideas and information instantly, without barriers\".",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/X_(social_network)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "x",
+    "fact_type": "mission",
+    "format": "flashcard",
+    "question": "What is X (formerly Twitter)'s mission statement?",
+    "answer": "To give everyone the power to create and share ideas and information instantly, without barriers",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/X_(social_network)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "x",
+    "fact_type": "product",
+    "format": "quiz",
+    "question": "Which of these is a X (formerly Twitter) product or service?",
+    "answer": "X (Twitter)",
+    "options": [
+      "Netflix",
+      "Hulu",
+      "Amazon Prime Video"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/X_(social_network)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "x",
+    "fact_type": "product",
+    "format": "factoid",
+    "question": null,
+    "answer": "Key X (formerly Twitter) products and services include X (Twitter), X Premium, X Spaces, X Communities, X Blue.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/X_(social_network)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "x",
+    "fact_type": "acquisition",
+    "format": "quiz",
+    "question": "Which company did X (formerly Twitter) acquire in 2015?",
+    "answer": "Periscope",
+    "options": [
+      "Lucasfilm",
+      "Marvel",
+      "Pixar"
+    ],
+    "source_url": "https://en.wikipedia.org/wiki/X_(social_network)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "x",
+    "fact_type": "acquisition",
+    "format": "factoid",
+    "question": null,
+    "answer": "X (formerly Twitter) acquired Periscope in 2015.",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/X_(social_network)",
+    "source_date": "2026-01-19"
+  },
+  {
+    "company_slug": "x",
+    "fact_type": "acquisition",
+    "format": "flashcard",
+    "question": "In what year did X (formerly Twitter) acquire Vine?",
+    "answer": "2012",
+    "options": null,
+    "source_url": "https://en.wikipedia.org/wiki/X_(social_network)",
+    "source_date": "2026-01-19"
+  }
+]

--- a/scripts/generate-trivia-media-entertainment.ts
+++ b/scripts/generate-trivia-media-entertainment.ts
@@ -1,0 +1,540 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Generate company trivia for Media/Entertainment batch
+ * Issue #93
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Trivia item interface matching the Python generator
+interface TriviaItem {
+  company_slug: string;
+  fact_type: 'founding' | 'hq' | 'mission' | 'product' | 'news' | 'exec' | 'acquisition';
+  format: 'quiz' | 'flashcard' | 'factoid';
+  question: string | null;
+  answer: string;
+  options: string[] | null;
+  source_url: string | null;
+  source_date: string | null;
+}
+
+// Media/Entertainment company data
+const mediaEntertainmentCompanies: Record<string, {
+  name: string;
+  foundingYear: string;
+  founders: string[];
+  hq: string;
+  ceo: string;
+  mission: string;
+  products: string[];
+  acquisitions: { name: string; year: string }[];
+  wikipedia: string;
+}> = {
+  disney: {
+    name: 'Disney',
+    foundingYear: '1923',
+    founders: ['Walt Disney', 'Roy O. Disney'],
+    hq: 'Burbank, California',
+    ceo: 'Bob Iger',
+    mission: 'To entertain, inform and inspire people around the globe through the power of unparalleled storytelling',
+    products: ['Disney+', 'Walt Disney Studios', 'Pixar', 'Marvel Studios', 'Lucasfilm', 'ESPN', 'ABC', 'Disneyland', 'Walt Disney World'],
+    acquisitions: [
+      { name: '21st Century Fox', year: '2019' },
+      { name: 'Lucasfilm', year: '2012' },
+      { name: 'Marvel Entertainment', year: '2009' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/The_Walt_Disney_Company'
+  },
+  'warner-bros-discovery': {
+    name: 'Warner Bros. Discovery',
+    foundingYear: '2022',
+    founders: ['Formed from merger of WarnerMedia and Discovery, Inc.'],
+    hq: 'New York, New York',
+    ceo: 'David Zaslav',
+    mission: 'To be the preeminent global entertainment company',
+    products: ['Max', 'HBO', 'Warner Bros. Pictures', 'Discovery Channel', 'CNN', 'TBS', 'TNT', 'DC Studios'],
+    acquisitions: [
+      { name: 'WarnerMedia (merger)', year: '2022' },
+      { name: 'Scripps Networks Interactive', year: '2018' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Warner_Bros._Discovery'
+  },
+  spotify: {
+    name: 'Spotify',
+    foundingYear: '2006',
+    founders: ['Daniel Ek', 'Martin Lorentzon'],
+    hq: 'Stockholm, Sweden',
+    ceo: 'Daniel Ek',
+    mission: 'To unlock the potential of human creativity by giving a million creative artists the opportunity to live off their art',
+    products: ['Spotify Free', 'Spotify Premium', 'Spotify for Artists', 'Spotify for Podcasters', 'Spotify Wrapped'],
+    acquisitions: [
+      { name: 'Anchor', year: '2019' },
+      { name: 'Gimlet Media', year: '2019' },
+      { name: 'The Ringer', year: '2020' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Spotify'
+  },
+  bytedance: {
+    name: 'ByteDance',
+    foundingYear: '2012',
+    founders: ['Zhang Yiming'],
+    hq: 'Beijing, China',
+    ceo: 'Liang Rubo',
+    mission: 'To inspire creativity and bring joy',
+    products: ['TikTok', 'Douyin', 'Toutiao', 'CapCut', 'Lark', 'Pico VR'],
+    acquisitions: [
+      { name: 'Musical.ly', year: '2017' },
+      { name: 'Pico', year: '2021' },
+      { name: 'Moonton', year: '2021' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/ByteDance'
+  },
+  snap: {
+    name: 'Snap Inc.',
+    foundingYear: '2011',
+    founders: ['Evan Spiegel', 'Bobby Murphy', 'Reggie Brown'],
+    hq: 'Santa Monica, California',
+    ceo: 'Evan Spiegel',
+    mission: 'To empower people to express themselves, live in the moment, learn about the world, and have fun together',
+    products: ['Snapchat', 'Snap Map', 'Snap Spectacles', 'Bitmoji', 'Snap Camera'],
+    acquisitions: [
+      { name: 'Bitmoji', year: '2016' },
+      { name: 'Zenly', year: '2017' },
+      { name: 'Voisey', year: '2020' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Snap_Inc.'
+  },
+  pinterest: {
+    name: 'Pinterest',
+    foundingYear: '2010',
+    founders: ['Ben Silbermann', 'Paul Sciarra', 'Evan Sharp'],
+    hq: 'San Francisco, California',
+    ceo: 'Bill Ready',
+    mission: 'To bring everyone the inspiration to create a life they love',
+    products: ['Pinterest', 'Pinterest Lens', 'Pinterest Shopping', 'Idea Pins', 'Pinterest TV'],
+    acquisitions: [
+      { name: 'THE YES', year: '2022' },
+      { name: 'Vochi', year: '2021' },
+      { name: 'Instapaper', year: '2016' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Pinterest'
+  },
+  reddit: {
+    name: 'Reddit',
+    foundingYear: '2005',
+    founders: ['Steve Huffman', 'Alexis Ohanian'],
+    hq: 'San Francisco, California',
+    ceo: 'Steve Huffman',
+    mission: 'To bring community, belonging, and empowerment to everyone in the world',
+    products: ['Reddit', 'Reddit Premium', 'Reddit Coins', 'Reddit Awards', 'Reddit Chat'],
+    acquisitions: [
+      { name: 'Dubsmash', year: '2020' },
+      { name: 'Spiketrap', year: '2022' },
+      { name: 'MeaningCloud', year: '2022' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Reddit'
+  },
+  linkedin: {
+    name: 'LinkedIn',
+    foundingYear: '2002',
+    founders: ['Reid Hoffman', 'Allen Blue', 'Konstantin Guericke', 'Eric Ly', 'Jean-Luc Vaillant'],
+    hq: 'Sunnyvale, California',
+    ceo: 'Ryan Roslansky',
+    mission: 'To connect the world\'s professionals to make them more productive and successful',
+    products: ['LinkedIn', 'LinkedIn Learning', 'LinkedIn Premium', 'LinkedIn Recruiter', 'LinkedIn Sales Navigator'],
+    acquisitions: [
+      { name: 'Lynda.com', year: '2015' },
+      { name: 'SlideShare', year: '2012' },
+      { name: 'Glint', year: '2018' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/LinkedIn'
+  },
+  x: {
+    name: 'X (formerly Twitter)',
+    foundingYear: '2006',
+    founders: ['Jack Dorsey', 'Noah Glass', 'Biz Stone', 'Evan Williams'],
+    hq: 'San Francisco, California',
+    ceo: 'Linda Yaccarino',
+    mission: 'To give everyone the power to create and share ideas and information instantly, without barriers',
+    products: ['X (Twitter)', 'X Premium', 'X Spaces', 'X Communities', 'X Blue'],
+    acquisitions: [
+      { name: 'Periscope', year: '2015' },
+      { name: 'Vine', year: '2012' },
+      { name: 'MoPub', year: '2013' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/X_(social_network)'
+  },
+  ea: {
+    name: 'Electronic Arts (EA)',
+    foundingYear: '1982',
+    founders: ['Trip Hawkins'],
+    hq: 'Redwood City, California',
+    ceo: 'Andrew Wilson',
+    mission: 'To inspire the world to play',
+    products: ['EA Sports FC', 'Madden NFL', 'The Sims', 'Apex Legends', 'Battlefield', 'Mass Effect', 'Dragon Age'],
+    acquisitions: [
+      { name: 'Respawn Entertainment', year: '2017' },
+      { name: 'Codemasters', year: '2021' },
+      { name: 'Glu Mobile', year: '2021' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Electronic_Arts'
+  },
+  'activision-blizzard': {
+    name: 'Activision Blizzard',
+    foundingYear: '2008',
+    founders: ['Formed from merger of Activision and Vivendi Games'],
+    hq: 'Santa Monica, California',
+    ceo: 'Bobby Kotick (until acquisition)',
+    mission: 'To connect and engage the world through epic entertainment',
+    products: ['Call of Duty', 'World of Warcraft', 'Overwatch', 'Candy Crush', 'Diablo', 'Hearthstone', 'StarCraft'],
+    acquisitions: [
+      { name: 'King Digital Entertainment', year: '2016' },
+      { name: 'Major League Gaming', year: '2016' },
+      { name: 'Acquired by Microsoft', year: '2023' }
+    ],
+    wikipedia: 'https://en.wikipedia.org/wiki/Activision_Blizzard'
+  }
+};
+
+function generateFoundingTrivia(slug: string, company: typeof mediaEntertainmentCompanies[string]): TriviaItem[] {
+  const items: TriviaItem[] = [];
+  const sourceDate = new Date().toISOString().split('T')[0] ?? null;
+
+  // Quiz: Founding year
+  items.push({
+    company_slug: slug,
+    fact_type: 'founding',
+    format: 'quiz',
+    question: `When was ${company.name} founded?`,
+    answer: company.foundingYear,
+    options: generateYearOptions(company.foundingYear),
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Flashcard: Founders
+  const foundersList = company.founders.length > 2
+    ? company.founders.slice(0, 2).join(' and ') + ' and others'
+    : company.founders.join(' and ');
+  items.push({
+    company_slug: slug,
+    fact_type: 'founding',
+    format: 'flashcard',
+    question: `Who founded ${company.name}?`,
+    answer: foundersList,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Factoid
+  items.push({
+    company_slug: slug,
+    fact_type: 'founding',
+    format: 'factoid',
+    question: null,
+    answer: `${company.name} was founded in ${company.foundingYear} by ${foundersList}.`,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  return items;
+}
+
+function generateHqTrivia(slug: string, company: typeof mediaEntertainmentCompanies[string]): TriviaItem[] {
+  const items: TriviaItem[] = [];
+  const sourceDate = new Date().toISOString().split('T')[0] ?? null;
+
+  // Quiz: Headquarters
+  items.push({
+    company_slug: slug,
+    fact_type: 'hq',
+    format: 'quiz',
+    question: `Where is ${company.name}'s headquarters located?`,
+    answer: company.hq,
+    options: generateHqOptions(company.hq),
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Flashcard
+  items.push({
+    company_slug: slug,
+    fact_type: 'hq',
+    format: 'flashcard',
+    question: `What city is ${company.name} headquartered in?`,
+    answer: company.hq,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  return items;
+}
+
+function generateExecTrivia(slug: string, company: typeof mediaEntertainmentCompanies[string]): TriviaItem[] {
+  const items: TriviaItem[] = [];
+  const sourceDate = new Date().toISOString().split('T')[0] ?? null;
+
+  // Quiz: CEO
+  items.push({
+    company_slug: slug,
+    fact_type: 'exec',
+    format: 'quiz',
+    question: `Who is the current CEO of ${company.name}?`,
+    answer: company.ceo,
+    options: generateCeoOptions(company.ceo, slug),
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Flashcard
+  items.push({
+    company_slug: slug,
+    fact_type: 'exec',
+    format: 'flashcard',
+    question: `Who leads ${company.name} as CEO?`,
+    answer: company.ceo,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  return items;
+}
+
+function generateMissionTrivia(slug: string, company: typeof mediaEntertainmentCompanies[string]): TriviaItem[] {
+  const items: TriviaItem[] = [];
+  const sourceDate = new Date().toISOString().split('T')[0] ?? null;
+
+  // Factoid: Mission
+  items.push({
+    company_slug: slug,
+    fact_type: 'mission',
+    format: 'factoid',
+    question: null,
+    answer: `${company.name}'s mission is "${company.mission}".`,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Flashcard
+  items.push({
+    company_slug: slug,
+    fact_type: 'mission',
+    format: 'flashcard',
+    question: `What is ${company.name}'s mission statement?`,
+    answer: company.mission,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  return items;
+}
+
+function generateProductTrivia(slug: string, company: typeof mediaEntertainmentCompanies[string]): TriviaItem[] {
+  const items: TriviaItem[] = [];
+  const sourceDate = new Date().toISOString().split('T')[0] ?? null;
+
+  // Quiz: Products
+  const mainProduct = company.products[0];
+  items.push({
+    company_slug: slug,
+    fact_type: 'product',
+    format: 'quiz',
+    question: `Which of these is a ${company.name} product or service?`,
+    answer: mainProduct!,
+    options: generateProductOptions(mainProduct!, slug),
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Factoid: Products list
+  const productsList = company.products.slice(0, 5).join(', ');
+  items.push({
+    company_slug: slug,
+    fact_type: 'product',
+    format: 'factoid',
+    question: null,
+    answer: `Key ${company.name} products and services include ${productsList}.`,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  return items;
+}
+
+function generateAcquisitionTrivia(slug: string, company: typeof mediaEntertainmentCompanies[string]): TriviaItem[] {
+  const items: TriviaItem[] = [];
+  const sourceDate = new Date().toISOString().split('T')[0] ?? null;
+
+  if (company.acquisitions.length === 0) return items;
+
+  // Quiz: Notable acquisition
+  const mainAcquisition = company.acquisitions[0];
+  items.push({
+    company_slug: slug,
+    fact_type: 'acquisition',
+    format: 'quiz',
+    question: `Which company did ${company.name} acquire in ${mainAcquisition!.year}?`,
+    answer: mainAcquisition!.name,
+    options: generateAcquisitionOptions(mainAcquisition!.name),
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Factoid
+  items.push({
+    company_slug: slug,
+    fact_type: 'acquisition',
+    format: 'factoid',
+    question: null,
+    answer: `${company.name} acquired ${mainAcquisition!.name} in ${mainAcquisition!.year}.`,
+    options: null,
+    source_url: company.wikipedia,
+    source_date: sourceDate
+  });
+
+  // Additional acquisition if available
+  if (company.acquisitions.length > 1) {
+    const secondAcquisition = company.acquisitions[1];
+    items.push({
+      company_slug: slug,
+      fact_type: 'acquisition',
+      format: 'flashcard',
+      question: `In what year did ${company.name} acquire ${secondAcquisition!.name}?`,
+      answer: secondAcquisition!.year,
+      options: null,
+      source_url: company.wikipedia,
+      source_date: sourceDate
+    });
+  }
+
+  return items;
+}
+
+function generateYearOptions(correctYear: string): string[] {
+  const year = parseInt(correctYear);
+  const options: string[] = [];
+  // For older companies (before 1990), use larger offsets
+  if (year < 1990) {
+    const offsets = [-8, -4, 5];
+    for (const offset of offsets) {
+      options.push((year + offset).toString());
+    }
+  } else {
+    const offsets = [-5, -2, 3];
+    for (const offset of offsets) {
+      options.push((year + offset).toString());
+    }
+  }
+  return options;
+}
+
+function generateHqOptions(correctHq: string): string[] {
+  const hqOptions = [
+    'San Francisco, California',
+    'New York, New York',
+    'Los Angeles, California',
+    'Seattle, Washington',
+    'Austin, Texas',
+    'Boston, Massachusetts',
+    'Mountain View, California',
+    'Palo Alto, California',
+    'Burbank, California',
+    'Santa Monica, California',
+    'Redwood City, California',
+    'Sunnyvale, California',
+    'Stockholm, Sweden',
+    'Beijing, China',
+    'London, United Kingdom'
+  ];
+  return hqOptions.filter(hq => hq !== correctHq).slice(0, 3);
+}
+
+function generateCeoOptions(correctCeo: string, companySlug: string): string[] {
+  const ceoOptions: Record<string, string[]> = {
+    disney: ['David Zaslav', 'Reed Hastings', 'Tim Cook'],
+    'warner-bros-discovery': ['Bob Iger', 'Reed Hastings', 'Brian Roberts'],
+    spotify: ['Reed Hastings', 'Evan Spiegel', 'Mark Zuckerberg'],
+    bytedance: ['Daniel Ek', 'Mark Zuckerberg', 'Evan Spiegel'],
+    snap: ['Mark Zuckerberg', 'Ben Silbermann', 'Steve Huffman'],
+    pinterest: ['Evan Spiegel', 'Steve Huffman', 'Mark Zuckerberg'],
+    reddit: ['Ben Silbermann', 'Evan Spiegel', 'Jack Dorsey'],
+    linkedin: ['Mark Zuckerberg', 'Steve Huffman', 'Jeff Weiner'],
+    x: ['Elon Musk', 'Jack Dorsey', 'Mark Zuckerberg'],
+    ea: ['Bobby Kotick', 'Phil Spencer', 'Satya Nadella'],
+    'activision-blizzard': ['Andrew Wilson', 'Phil Spencer', 'Jim Ryan']
+  };
+  return ceoOptions[companySlug] || ['Mark Zuckerberg', 'Evan Spiegel', 'Reed Hastings'];
+}
+
+function generateProductOptions(correctProduct: string, companySlug: string): string[] {
+  const allProducts = [
+    'Netflix', 'Hulu', 'Amazon Prime Video', 'Apple TV+', 'YouTube',
+    'Facebook', 'Instagram', 'WhatsApp', 'TikTok', 'Snapchat',
+    'Twitch', 'Discord', 'Steam', 'PlayStation Network', 'Xbox Game Pass',
+    'Fortnite', 'League of Legends', 'Roblox', 'Minecraft', 'Among Us'
+  ];
+  return allProducts.filter(p => p !== correctProduct).slice(0, 3);
+}
+
+function generateAcquisitionOptions(correctAcquisition: string): string[] {
+  const acquisitionOptions = [
+    'Lucasfilm', 'Marvel', 'Pixar', '21st Century Fox', 'MGM',
+    'Twitch', 'Instagram', 'WhatsApp', 'YouTube', 'LinkedIn',
+    'Spotify', 'Discord', 'Snap', 'Pinterest', 'Reddit',
+    'King', 'Zynga', 'Bungie', 'Bethesda', 'Activision Blizzard'
+  ];
+  return acquisitionOptions.filter(a => a !== correctAcquisition).slice(0, 3);
+}
+
+function generateCompanyTrivia(slug: string): TriviaItem[] {
+  const company = mediaEntertainmentCompanies[slug];
+  if (!company) {
+    console.warn(`No data for company: ${slug}`);
+    return [];
+  }
+
+  const items: TriviaItem[] = [
+    ...generateFoundingTrivia(slug, company),
+    ...generateHqTrivia(slug, company),
+    ...generateExecTrivia(slug, company),
+    ...generateMissionTrivia(slug, company),
+    ...generateProductTrivia(slug, company),
+    ...generateAcquisitionTrivia(slug, company)
+  ];
+
+  return items;
+}
+
+function main() {
+  const outputDir = path.join(process.cwd(), 'data', 'generated', 'trivia');
+
+  // Ensure output directory exists
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  const slugs = Object.keys(mediaEntertainmentCompanies);
+  let totalItems = 0;
+
+  for (const slug of slugs) {
+    const items = generateCompanyTrivia(slug);
+    const outputPath = path.join(outputDir, `${slug}.json`);
+
+    fs.writeFileSync(outputPath, JSON.stringify(items, null, 2));
+    console.log(`Generated ${items.length} trivia items for ${slug}`);
+    totalItems += items.length;
+  }
+
+  console.log(`\nTotal: ${totalItems} trivia items for ${slugs.length} Media/Entertainment companies`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add trivia generation script for Media/Entertainment companies
- Generate 154 trivia items (14 per company) for 11 companies:
  - Disney, Warner Bros. Discovery, Spotify, ByteDance
  - Snap, Pinterest, Reddit, LinkedIn
  - X (Twitter), EA, Activision Blizzard

## Test plan
- [x] Script runs without errors
- [x] 11 trivia files generated in `data/generated/trivia/`
- [x] Each file contains 14 trivia items
- [x] Quiz items have exactly 3 wrong options
- [x] All items have source_url and source_date
- [x] Lint passes
- [x] Type check passes
- [x] Build succeeds
- [x] Tests pass (2163 passed, 12 pre-existing failures unrelated)

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)