### PR TITLE
Add Big Tech company themes (#94)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -3290,3 +3290,38 @@ All Stage 5 (Launch) code issues are now closed:
 - Quiz items have exactly 3 wrong options
 - All items have source_url and source_date
 
+
+### 2026-01-18 - Issue #94: Expand company themes: Big Tech batch
+
+**Completed:**
+- Created Supabase migration for Big Tech company themes
+- Created JSON theme data file for content loader
+- Added brand colors and logos for 12 Big Tech companies:
+  - Google (#4285f4 blue, #34a853 green)
+  - Meta (#0866ff blue, #1877f2 dark blue)
+  - Amazon (#ff9900 orange, #232f3e dark)
+  - Apple (#000000 black, #86868b gray)
+  - Microsoft (#00a4ef blue, #737373 gray)
+  - Netflix (#e50914 red, #221f1f dark)
+  - NVIDIA (#76b900 green, #000000 black)
+  - Intel (#0071c5 blue, #00c7fd light blue)
+  - AMD (#ed1c24 red, #1a1a1d dark)
+  - Cisco (#049fd9 blue, #005073 navy)
+  - Tesla (#e82127 red, #000000 black)
+  - Adobe (#ff0000 red, #fa0f00 dark red)
+
+**Files Created:**
+- `supabase/migrations/20260119000002_insert_big_tech_themes.sql`
+- `data/generated/themes/big-tech.json` (12 themes)
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - theme tests pass (109 tests)
+- JSON file validated with jq
+- All acceptance criteria verified:
+  - Theme data for 12 Big Tech companies
+  - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
+  - Migration uses ON CONFLICT for upsert (updates existing themes)
+

--- a/data/generated/themes/big-tech.json
+++ b/data/generated/themes/big-tech.json
@@ -1,0 +1,90 @@
+{
+  "batch": "Big Tech",
+  "generated_at": "2026-01-18",
+  "themes": [
+    {
+      "company_slug": "google",
+      "logo_url": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "primary_color": "#4285f4",
+      "secondary_color": "#34a853",
+      "industry_category": "Big Tech"
+    },
+    {
+      "company_slug": "meta",
+      "logo_url": "https://about.meta.com/brand/resources/facebookapp/logo/",
+      "primary_color": "#0866ff",
+      "secondary_color": "#1877f2",
+      "industry_category": "Big Tech"
+    },
+    {
+      "company_slug": "amazon",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/Amazon_logo.svg",
+      "primary_color": "#ff9900",
+      "secondary_color": "#232f3e",
+      "industry_category": "Big Tech"
+    },
+    {
+      "company_slug": "apple",
+      "logo_url": "https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_apple_image__b5er5ngrzxqq_large.svg",
+      "primary_color": "#000000",
+      "secondary_color": "#86868b",
+      "industry_category": "Big Tech"
+    },
+    {
+      "company_slug": "microsoft",
+      "logo_url": "https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1Mu3b",
+      "primary_color": "#00a4ef",
+      "secondary_color": "#737373",
+      "industry_category": "Big Tech"
+    },
+    {
+      "company_slug": "netflix",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/0/08/Netflix_2015_logo.svg",
+      "primary_color": "#e50914",
+      "secondary_color": "#221f1f",
+      "industry_category": "Big Tech"
+    },
+    {
+      "company_slug": "nvidia",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/21/Nvidia_logo.svg",
+      "primary_color": "#76b900",
+      "secondary_color": "#000000",
+      "industry_category": "Big Tech"
+    },
+    {
+      "company_slug": "intel",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/c/c9/Intel-logo.svg",
+      "primary_color": "#0071c5",
+      "secondary_color": "#00c7fd",
+      "industry_category": "Big Tech"
+    },
+    {
+      "company_slug": "amd",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/7/7c/AMD_Logo.svg",
+      "primary_color": "#ed1c24",
+      "secondary_color": "#1a1a1d",
+      "industry_category": "Big Tech"
+    },
+    {
+      "company_slug": "cisco",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/6/64/Cisco_logo.svg",
+      "primary_color": "#049fd9",
+      "secondary_color": "#005073",
+      "industry_category": "Big Tech"
+    },
+    {
+      "company_slug": "tesla",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg",
+      "primary_color": "#e82127",
+      "secondary_color": "#000000",
+      "industry_category": "Big Tech"
+    },
+    {
+      "company_slug": "adobe",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/8/8d/Adobe_Corporate_Logo.svg",
+      "primary_color": "#ff0000",
+      "secondary_color": "#fa0f00",
+      "industry_category": "Big Tech"
+    }
+  ]
+}

--- a/supabase/migrations/20260119000002_insert_big_tech_themes.sql
+++ b/supabase/migrations/20260119000002_insert_big_tech_themes.sql
@@ -1,0 +1,54 @@
+-- Migration: Insert Big Tech company themes
+-- Issue: #94 - Expand company themes: Big Tech batch
+
+-- Insert or update theme data for Big Tech companies
+-- Uses ON CONFLICT to update existing themes (Google, Apple, Microsoft already exist)
+
+INSERT INTO company_themes (company_slug, logo_url, primary_color, secondary_color, industry_category)
+VALUES
+  -- Google (update existing with verified colors)
+  ('google', 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png', '#4285f4', '#34a853', 'Big Tech'),
+
+  -- Meta (Facebook)
+  ('meta', 'https://about.meta.com/brand/resources/facebookapp/logo/', '#0866ff', '#1877f2', 'Big Tech'),
+
+  -- Amazon
+  ('amazon', 'https://upload.wikimedia.org/wikipedia/commons/a/a9/Amazon_logo.svg', '#ff9900', '#232f3e', 'Big Tech'),
+
+  -- Apple (update existing)
+  ('apple', 'https://www.apple.com/ac/globalnav/7/en_US/images/be15095f-5a20-57d0-ad14-cf4c638e223a/globalnav_apple_image__b5er5ngrzxqq_large.svg', '#000000', '#86868b', 'Big Tech'),
+
+  -- Microsoft (update existing)
+  ('microsoft', 'https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1Mu3b', '#00a4ef', '#737373', 'Big Tech'),
+
+  -- Netflix
+  ('netflix', 'https://upload.wikimedia.org/wikipedia/commons/0/08/Netflix_2015_logo.svg', '#e50914', '#221f1f', 'Big Tech'),
+
+  -- NVIDIA
+  ('nvidia', 'https://upload.wikimedia.org/wikipedia/commons/2/21/Nvidia_logo.svg', '#76b900', '#000000', 'Big Tech'),
+
+  -- Intel
+  ('intel', 'https://upload.wikimedia.org/wikipedia/commons/c/c9/Intel-logo.svg', '#0071c5', '#00c7fd', 'Big Tech'),
+
+  -- AMD
+  ('amd', 'https://upload.wikimedia.org/wikipedia/commons/7/7c/AMD_Logo.svg', '#ed1c24', '#1a1a1d', 'Big Tech'),
+
+  -- Cisco
+  ('cisco', 'https://upload.wikimedia.org/wikipedia/commons/6/64/Cisco_logo.svg', '#049fd9', '#005073', 'Big Tech'),
+
+  -- Tesla
+  ('tesla', 'https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg', '#e82127', '#000000', 'Big Tech'),
+
+  -- Adobe
+  ('adobe', 'https://upload.wikimedia.org/wikipedia/commons/8/8d/Adobe_Corporate_Logo.svg', '#ff0000', '#fa0f00', 'Big Tech')
+
+ON CONFLICT (company_slug)
+DO UPDATE SET
+  logo_url = EXCLUDED.logo_url,
+  primary_color = EXCLUDED.primary_color,
+  secondary_color = EXCLUDED.secondary_color,
+  industry_category = EXCLUDED.industry_category,
+  updated_at = NOW();
+
+-- Verify the insertions
+-- Expected: 12 companies in Big Tech category


### PR DESCRIPTION
## Summary
- Add brand colors and logos for 12 Big Tech companies
- Create Supabase migration for theme data
- Create JSON theme data file for content loader

## Companies Added
- Google (#4285f4 blue, #34a853 green)
- Meta (#0866ff blue, #1877f2 dark blue)
- Amazon (#ff9900 orange, #232f3e dark)
- Apple (#000000 black, #86868b gray)
- Microsoft (#00a4ef blue, #737373 gray)
- Netflix (#e50914 red, #221f1f dark)
- NVIDIA (#76b900 green, #000000 black)
- Intel (#0071c5 blue, #00c7fd light blue)
- AMD (#ed1c24 red, #1a1a1d dark)
- Cisco (#049fd9 blue, #005073 navy)
- Tesla (#e82127 red, #000000 black)
- Adobe (#ff0000 red, #fa0f00 dark red)

## Test plan
- [x] Lint passes
- [x] Type-check passes
- [x] Build succeeds
- [x] Theme tests pass (109 tests)
- [x] JSON file validates with jq

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)