### PR TITLE
Add high-growth startup company themes (#95)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -3325,3 +3325,39 @@ All Stage 5 (Launch) code issues are now closed:
   - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
   - Migration uses ON CONFLICT for upsert (updates existing themes)
 
+### 2026-01-19 - Issue #95: Expand company themes: High-growth startups batch
+
+**Completed:**
+- Created Supabase migration for high-growth startup company themes
+- Created JSON theme data file for content loader
+- Added brand colors and logos for 14 high-growth startup companies:
+  - Stripe (#635BFF purple, #32325D dark)
+  - Figma (#F24E1E orange, #A259FF purple)
+  - Notion (#000000 black, #FFFFFF white)
+  - Vercel (#000000 black, #FFFFFF white)
+  - Databricks (#FF3621 red-orange, #1B3139 dark)
+  - Snowflake (#29B5E8 blue, #0052CC dark blue)
+  - Airbnb (#FF5A5F coral, #484848 dark gray)
+  - Uber (#000000 black, #FFFFFF white)
+  - Lyft (#FF00BF pink, #11111F dark)
+  - DoorDash (#FF3008 red, #191919 dark)
+  - Instacart (#0AAD05 green, #003D29 dark green)
+  - Coinbase (#0052FF blue, #0A0B0D dark)
+  - Robinhood (#00C805 green, #000000 black)
+  - Plaid (#000000 black, #109DD7 blue)
+
+**Files Created:**
+- `supabase/migrations/20260119000003_insert_startup_themes.sql`
+- `data/generated/themes/high-growth-startups.json` (14 themes)
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - 2163 passed, 2 todo, 12 pre-existing failures (unrelated to this change)
+- JSON file validated with jq
+- All acceptance criteria verified:
+  - Theme data for 14 high-growth startup companies
+  - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
+  - Migration uses ON CONFLICT for upsert (updates existing themes)
+

--- a/data/generated/themes/high-growth-startups.json
+++ b/data/generated/themes/high-growth-startups.json
@@ -1,0 +1,104 @@
+{
+  "batch": "High-growth Startups",
+  "generated_at": "2026-01-19",
+  "themes": [
+    {
+      "company_slug": "stripe",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/b/ba/Stripe_Logo%2C_revised_2016.svg",
+      "primary_color": "#635BFF",
+      "secondary_color": "#32325D",
+      "industry_category": "High-growth Startups"
+    },
+    {
+      "company_slug": "figma",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/3/33/Figma-logo.svg",
+      "primary_color": "#F24E1E",
+      "secondary_color": "#A259FF",
+      "industry_category": "High-growth Startups"
+    },
+    {
+      "company_slug": "notion",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png",
+      "primary_color": "#000000",
+      "secondary_color": "#FFFFFF",
+      "industry_category": "High-growth Startups"
+    },
+    {
+      "company_slug": "vercel",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/5/5e/Vercel_logo_black.svg",
+      "primary_color": "#000000",
+      "secondary_color": "#FFFFFF",
+      "industry_category": "High-growth Startups"
+    },
+    {
+      "company_slug": "databricks",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/6/63/Databricks_Logo.png",
+      "primary_color": "#FF3621",
+      "secondary_color": "#1B3139",
+      "industry_category": "High-growth Startups"
+    },
+    {
+      "company_slug": "snowflake",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/f/ff/Snowflake_Logo.svg",
+      "primary_color": "#29B5E8",
+      "secondary_color": "#0052CC",
+      "industry_category": "High-growth Startups"
+    },
+    {
+      "company_slug": "airbnb",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/6/69/Airbnb_Logo_B%C3%A9lo.svg",
+      "primary_color": "#FF5A5F",
+      "secondary_color": "#484848",
+      "industry_category": "High-growth Startups"
+    },
+    {
+      "company_slug": "uber",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/c/cc/Uber_logo_2018.png",
+      "primary_color": "#000000",
+      "secondary_color": "#FFFFFF",
+      "industry_category": "High-growth Startups"
+    },
+    {
+      "company_slug": "lyft",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a0/Lyft_logo.svg",
+      "primary_color": "#FF00BF",
+      "secondary_color": "#11111F",
+      "industry_category": "High-growth Startups"
+    },
+    {
+      "company_slug": "doordash",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/c/c6/DoorDash_logo.png",
+      "primary_color": "#FF3008",
+      "secondary_color": "#191919",
+      "industry_category": "High-growth Startups"
+    },
+    {
+      "company_slug": "instacart",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/9f/Instacart_logo_and_wordmark.svg",
+      "primary_color": "#0AAD05",
+      "secondary_color": "#003D29",
+      "industry_category": "High-growth Startups"
+    },
+    {
+      "company_slug": "coinbase",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/1/1a/Coinbase.svg",
+      "primary_color": "#0052FF",
+      "secondary_color": "#0A0B0D",
+      "industry_category": "High-growth Startups"
+    },
+    {
+      "company_slug": "robinhood",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/ac/Robinhood_wordmark.png",
+      "primary_color": "#00C805",
+      "secondary_color": "#000000",
+      "industry_category": "High-growth Startups"
+    },
+    {
+      "company_slug": "plaid",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/1/19/Plaid_logo.svg",
+      "primary_color": "#000000",
+      "secondary_color": "#109DD7",
+      "industry_category": "High-growth Startups"
+    }
+  ]
+}

--- a/supabase/migrations/20260119000003_insert_startup_themes.sql
+++ b/supabase/migrations/20260119000003_insert_startup_themes.sql
@@ -1,0 +1,60 @@
+-- Migration: Insert High-growth Startups company themes
+-- Issue: #95 - Expand company themes: High-growth startups batch
+
+-- Insert or update theme data for high-growth startup companies
+-- Uses ON CONFLICT to update existing themes
+
+INSERT INTO company_themes (company_slug, logo_url, primary_color, secondary_color, industry_category)
+VALUES
+  -- Stripe
+  ('stripe', 'https://upload.wikimedia.org/wikipedia/commons/b/ba/Stripe_Logo%2C_revised_2016.svg', '#635BFF', '#32325D', 'High-growth Startups'),
+
+  -- Figma
+  ('figma', 'https://upload.wikimedia.org/wikipedia/commons/3/33/Figma-logo.svg', '#F24E1E', '#A259FF', 'High-growth Startups'),
+
+  -- Notion
+  ('notion', 'https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png', '#000000', '#FFFFFF', 'High-growth Startups'),
+
+  -- Vercel
+  ('vercel', 'https://upload.wikimedia.org/wikipedia/commons/5/5e/Vercel_logo_black.svg', '#000000', '#FFFFFF', 'High-growth Startups'),
+
+  -- Databricks
+  ('databricks', 'https://upload.wikimedia.org/wikipedia/commons/6/63/Databricks_Logo.png', '#FF3621', '#1B3139', 'High-growth Startups'),
+
+  -- Snowflake
+  ('snowflake', 'https://upload.wikimedia.org/wikipedia/commons/f/ff/Snowflake_Logo.svg', '#29B5E8', '#0052CC', 'High-growth Startups'),
+
+  -- Airbnb
+  ('airbnb', 'https://upload.wikimedia.org/wikipedia/commons/6/69/Airbnb_Logo_B%C3%A9lo.svg', '#FF5A5F', '#484848', 'High-growth Startups'),
+
+  -- Uber
+  ('uber', 'https://upload.wikimedia.org/wikipedia/commons/c/cc/Uber_logo_2018.png', '#000000', '#FFFFFF', 'High-growth Startups'),
+
+  -- Lyft
+  ('lyft', 'https://upload.wikimedia.org/wikipedia/commons/a/a0/Lyft_logo.svg', '#FF00BF', '#11111F', 'High-growth Startups'),
+
+  -- DoorDash
+  ('doordash', 'https://upload.wikimedia.org/wikipedia/commons/c/c6/DoorDash_logo.png', '#FF3008', '#191919', 'High-growth Startups'),
+
+  -- Instacart
+  ('instacart', 'https://upload.wikimedia.org/wikipedia/commons/9/9f/Instacart_logo_and_wordmark.svg', '#0AAD05', '#003D29', 'High-growth Startups'),
+
+  -- Coinbase
+  ('coinbase', 'https://upload.wikimedia.org/wikipedia/commons/1/1a/Coinbase.svg', '#0052FF', '#0A0B0D', 'High-growth Startups'),
+
+  -- Robinhood
+  ('robinhood', 'https://upload.wikimedia.org/wikipedia/commons/a/ac/Robinhood_wordmark.png', '#00C805', '#000000', 'High-growth Startups'),
+
+  -- Plaid
+  ('plaid', 'https://upload.wikimedia.org/wikipedia/commons/1/19/Plaid_logo.svg', '#000000', '#109DD7', 'High-growth Startups')
+
+ON CONFLICT (company_slug)
+DO UPDATE SET
+  logo_url = EXCLUDED.logo_url,
+  primary_color = EXCLUDED.primary_color,
+  secondary_color = EXCLUDED.secondary_color,
+  industry_category = EXCLUDED.industry_category,
+  updated_at = NOW();
+
+-- Verify the insertions
+-- Expected: 14 companies in High-growth Startups category


### PR DESCRIPTION
## Summary
- Add brand colors and logos for 14 high-growth startup companies
- Create Supabase migration for theme data with ON CONFLICT upsert
- Create JSON theme file for content loader

## Companies Added
| Company | Primary Color | Secondary Color |
|---------|---------------|-----------------|
| Stripe | #635BFF | #32325D |
| Figma | #F24E1E | #A259FF |
| Notion | #000000 | #FFFFFF |
| Vercel | #000000 | #FFFFFF |
| Databricks | #FF3621 | #1B3139 |
| Snowflake | #29B5E8 | #0052CC |
| Airbnb | #FF5A5F | #484848 |
| Uber | #000000 | #FFFFFF |
| Lyft | #FF00BF | #11111F |
| DoorDash | #FF3008 | #191919 |
| Instacart | #0AAD05 | #003D29 |
| Coinbase | #0052FF | #0A0B0D |
| Robinhood | #00C805 | #000000 |
| Plaid | #000000 | #109DD7 |

## Test plan
- [x] `npm run lint` passes
- [x] `npm run type-check` passes
- [x] `npm run build` passes
- [x] Theme tests pass (109 tests)
- [x] JSON file validates with jq

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)