### PR TITLE
Add Finance company themes (#96)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -3361,3 +3361,39 @@ All Stage 5 (Launch) code issues are now closed:
   - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
   - Migration uses ON CONFLICT for upsert (updates existing themes)
 
+### 2026-01-18 - Issue #96: Expand company themes: Finance batch
+
+**Completed:**
+- Created Supabase migration for Finance company themes
+- Created JSON theme data file for content loader
+- Added brand colors and logos for 14 Finance companies:
+  - Goldman Sachs (#7399C6 light blue, #0A1628 navy)
+  - JPMorgan Chase (#117ACA blue, #0D2B3E dark blue)
+  - Morgan Stanley (#00A0DF blue, #002D72 navy)
+  - Bank of America (#E31837 red, #012169 blue)
+  - Citadel (#003366 dark blue, #1A1A1A black)
+  - Two Sigma (#00A9E0 blue, #002855 dark blue)
+  - Jane Street (#007ACC blue, #1A1A1A black)
+  - BlackRock (#000000 black, #6D6E71 gray)
+  - Fidelity (#4AA564 green, #1A1A1A black)
+  - Charles Schwab (#00A0DF blue, #1A1A1A black)
+  - Visa (#1A1F71 blue, #F7B600 gold)
+  - Mastercard (#EB001B red, #F79E1B orange)
+  - PayPal (#003087 blue, #009CDE light blue)
+  - Block (#000000 black, #1DA1F2 blue)
+
+**Files Created:**
+- `supabase/migrations/20260119000004_insert_finance_themes.sql`
+- `data/generated/themes/finance.json` (14 themes)
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - theme tests pass (109 tests)
+- JSON file validated with jq
+- All acceptance criteria verified:
+  - Theme data for 14 Finance companies
+  - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
+  - Migration uses ON CONFLICT for upsert (updates existing themes)
+

--- a/data/generated/themes/finance.json
+++ b/data/generated/themes/finance.json
@@ -1,0 +1,104 @@
+{
+  "batch": "Finance",
+  "generated_at": "2026-01-18",
+  "themes": [
+    {
+      "company_slug": "goldman-sachs",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/6/61/Goldman_Sachs.svg",
+      "primary_color": "#7399C6",
+      "secondary_color": "#0A1628",
+      "industry_category": "Finance"
+    },
+    {
+      "company_slug": "jpmorgan",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/af/J_P_Morgan_Logo_2008_1.svg",
+      "primary_color": "#117ACA",
+      "secondary_color": "#0D2B3E",
+      "industry_category": "Finance"
+    },
+    {
+      "company_slug": "morgan-stanley",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/3/34/Morgan_Stanley_Logo_1.svg",
+      "primary_color": "#00A0DF",
+      "secondary_color": "#002D72",
+      "industry_category": "Finance"
+    },
+    {
+      "company_slug": "bank-of-america",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/20/Bank_of_America_logo.svg",
+      "primary_color": "#E31837",
+      "secondary_color": "#012169",
+      "industry_category": "Finance"
+    },
+    {
+      "company_slug": "citadel",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Citadel_LLC_Logo.svg",
+      "primary_color": "#003366",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Finance"
+    },
+    {
+      "company_slug": "two-sigma",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/5/51/Two_Sigma_Logo.svg",
+      "primary_color": "#00A9E0",
+      "secondary_color": "#002855",
+      "industry_category": "Finance"
+    },
+    {
+      "company_slug": "jane-street",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/6/6c/Jane_Street_Capital_Logo.svg",
+      "primary_color": "#007ACC",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Finance"
+    },
+    {
+      "company_slug": "blackrock",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/1/1e/BlackRock_wordmark.svg",
+      "primary_color": "#000000",
+      "secondary_color": "#6D6E71",
+      "industry_category": "Finance"
+    },
+    {
+      "company_slug": "fidelity",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/0/09/Fidelity_Investments_logo.svg",
+      "primary_color": "#4AA564",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Finance"
+    },
+    {
+      "company_slug": "charles-schwab",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/6/6c/Charles_Schwab_Corporation_logo.svg",
+      "primary_color": "#00A0DF",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Finance"
+    },
+    {
+      "company_slug": "visa",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/5/5e/Visa_Inc._logo.svg",
+      "primary_color": "#1A1F71",
+      "secondary_color": "#F7B600",
+      "industry_category": "Finance"
+    },
+    {
+      "company_slug": "mastercard",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/2a/Mastercard-logo.svg",
+      "primary_color": "#EB001B",
+      "secondary_color": "#F79E1B",
+      "industry_category": "Finance"
+    },
+    {
+      "company_slug": "paypal",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg",
+      "primary_color": "#003087",
+      "secondary_color": "#009CDE",
+      "industry_category": "Finance"
+    },
+    {
+      "company_slug": "block",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/5/55/Block%2C_Inc._logo.svg",
+      "primary_color": "#000000",
+      "secondary_color": "#1DA1F2",
+      "industry_category": "Finance"
+    }
+  ]
+}

--- a/supabase/migrations/20260119000004_insert_finance_themes.sql
+++ b/supabase/migrations/20260119000004_insert_finance_themes.sql
@@ -1,0 +1,60 @@
+-- Migration: Insert Finance company themes
+-- Issue: #96 - Expand company themes: Finance batch
+
+-- Insert or update theme data for Finance companies
+-- Uses ON CONFLICT to update existing themes
+
+INSERT INTO company_themes (company_slug, logo_url, primary_color, secondary_color, industry_category)
+VALUES
+  -- Goldman Sachs (light blue/navy brand)
+  ('goldman-sachs', 'https://upload.wikimedia.org/wikipedia/commons/6/61/Goldman_Sachs.svg', '#7399C6', '#0A1628', 'Finance'),
+
+  -- JPMorgan Chase (blue brand)
+  ('jpmorgan', 'https://upload.wikimedia.org/wikipedia/commons/a/af/J_P_Morgan_Logo_2008_1.svg', '#117ACA', '#0D2B3E', 'Finance'),
+
+  -- Morgan Stanley (blue brand)
+  ('morgan-stanley', 'https://upload.wikimedia.org/wikipedia/commons/3/34/Morgan_Stanley_Logo_1.svg', '#00A0DF', '#002D72', 'Finance'),
+
+  -- Bank of America (red/blue brand)
+  ('bank-of-america', 'https://upload.wikimedia.org/wikipedia/commons/2/20/Bank_of_America_logo.svg', '#E31837', '#012169', 'Finance'),
+
+  -- Citadel (dark blue brand)
+  ('citadel', 'https://upload.wikimedia.org/wikipedia/commons/3/3f/Citadel_LLC_Logo.svg', '#003366', '#1A1A1A', 'Finance'),
+
+  -- Two Sigma (blue brand)
+  ('two-sigma', 'https://upload.wikimedia.org/wikipedia/commons/5/51/Two_Sigma_Logo.svg', '#00A9E0', '#002855', 'Finance'),
+
+  -- Jane Street (blue brand)
+  ('jane-street', 'https://upload.wikimedia.org/wikipedia/commons/6/6c/Jane_Street_Capital_Logo.svg', '#007ACC', '#1A1A1A', 'Finance'),
+
+  -- BlackRock (black brand)
+  ('blackrock', 'https://upload.wikimedia.org/wikipedia/commons/1/1e/BlackRock_wordmark.svg', '#000000', '#6D6E71', 'Finance'),
+
+  -- Fidelity (green brand)
+  ('fidelity', 'https://upload.wikimedia.org/wikipedia/commons/0/09/Fidelity_Investments_logo.svg', '#4AA564', '#1A1A1A', 'Finance'),
+
+  -- Charles Schwab (blue brand)
+  ('charles-schwab', 'https://upload.wikimedia.org/wikipedia/commons/6/6c/Charles_Schwab_Corporation_logo.svg', '#00A0DF', '#1A1A1A', 'Finance'),
+
+  -- Visa (blue/gold brand)
+  ('visa', 'https://upload.wikimedia.org/wikipedia/commons/5/5e/Visa_Inc._logo.svg', '#1A1F71', '#F7B600', 'Finance'),
+
+  -- Mastercard (red/orange brand)
+  ('mastercard', 'https://upload.wikimedia.org/wikipedia/commons/2/2a/Mastercard-logo.svg', '#EB001B', '#F79E1B', 'Finance'),
+
+  -- PayPal (blue brand)
+  ('paypal', 'https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg', '#003087', '#009CDE', 'Finance'),
+
+  -- Block/Square (black brand)
+  ('block', 'https://upload.wikimedia.org/wikipedia/commons/5/55/Block%2C_Inc._logo.svg', '#000000', '#1DA1F2', 'Finance')
+
+ON CONFLICT (company_slug)
+DO UPDATE SET
+  logo_url = EXCLUDED.logo_url,
+  primary_color = EXCLUDED.primary_color,
+  secondary_color = EXCLUDED.secondary_color,
+  industry_category = EXCLUDED.industry_category,
+  updated_at = NOW();
+
+-- Verify the insertions
+-- Expected: 14 companies in Finance category


### PR DESCRIPTION
## Summary
- Add brand colors and logos for 14 Finance companies
- Create Supabase migration for theme data
- Create JSON theme data file for content loader

## Companies Added
Goldman Sachs, JPMorgan Chase, Morgan Stanley, Bank of America, Citadel, Two Sigma, Jane Street, BlackRock, Fidelity, Charles Schwab, Visa, Mastercard, PayPal, Block

## Test plan
- [x] `npm run lint` passes
- [x] `npm run type-check` passes
- [x] `npm run build` succeeds
- [x] `npm test -- --testPathPattern="theme"` passes (109 tests)
- [x] JSON file validated with jq
- [x] Each company has required fields: company_slug, logo_url, primary_color, secondary_color, industry_category

Closes #96

:robot: Generated with [Claude Code](https://claude.com/claude-code)