### PR TITLE
Add Consulting company themes (#97)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -3397,3 +3397,35 @@ All Stage 5 (Launch) code issues are now closed:
   - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
   - Migration uses ON CONFLICT for upsert (updates existing themes)
 
+### 2026-01-18 - Issue #97: Expand company themes: Consulting batch
+
+**Completed:**
+- Created Supabase migration for Consulting company themes
+- Created JSON theme data file for content loader
+- Added brand colors and logos for 10 Consulting companies:
+  - McKinsey & Company (#0033A0 dark blue, #1A1A1A black)
+  - Boston Consulting Group (#00A651 green, #1A1A1A black)
+  - Bain & Company (#CC0000 red, #1A1A1A black)
+  - Deloitte (#86BC25 green, #000000 black)
+  - Accenture (#A100FF purple, #1A1A1A black)
+  - PwC (#DC6900 orange, #1A1A1A black)
+  - EY (#FFE600 yellow, #2E2E38 dark)
+  - KPMG (#00338D blue, #1A1A1A black)
+  - Capgemini (#0070AD blue, #12ABDB light blue)
+  - Booz Allen Hamilton (#DA291C red, #1A1A1A black)
+
+**Files Created:**
+- `supabase/migrations/20260119000005_insert_consulting_themes.sql`
+- `data/generated/themes/consulting.json` (10 themes)
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - theme tests pass (109 tests)
+- JSON file validated with jq
+- All acceptance criteria verified:
+  - Theme data for 10 Consulting companies
+  - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
+  - Migration uses ON CONFLICT for upsert (updates existing themes)
+

--- a/data/generated/themes/consulting.json
+++ b/data/generated/themes/consulting.json
@@ -1,0 +1,76 @@
+{
+  "batch": "Consulting",
+  "generated_at": "2026-01-18",
+  "themes": [
+    {
+      "company_slug": "mckinsey",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a9/McKinsey_and_Company_Logo_1.svg",
+      "primary_color": "#0033A0",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Consulting"
+    },
+    {
+      "company_slug": "bcg",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/e/e7/Boston_Consulting_Group_2020_logo.svg",
+      "primary_color": "#00A651",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Consulting"
+    },
+    {
+      "company_slug": "bain",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/93/Bain_%26_Company_logo.svg",
+      "primary_color": "#CC0000",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Consulting"
+    },
+    {
+      "company_slug": "deloitte",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/5/56/Deloitte.svg",
+      "primary_color": "#86BC25",
+      "secondary_color": "#000000",
+      "industry_category": "Consulting"
+    },
+    {
+      "company_slug": "accenture",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/c/cd/Accenture.svg",
+      "primary_color": "#A100FF",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Consulting"
+    },
+    {
+      "company_slug": "pwc",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/0/05/PricewaterhouseCoopers_Logo.svg",
+      "primary_color": "#DC6900",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Consulting"
+    },
+    {
+      "company_slug": "ey",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/3/34/EY_logo_2019.svg",
+      "primary_color": "#FFE600",
+      "secondary_color": "#2E2E38",
+      "industry_category": "Consulting"
+    },
+    {
+      "company_slug": "kpmg",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/9d/KPMG_logo.svg",
+      "primary_color": "#00338D",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Consulting"
+    },
+    {
+      "company_slug": "capgemini",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/9d/Capgemini_logo.svg",
+      "primary_color": "#0070AD",
+      "secondary_color": "#12ABDB",
+      "industry_category": "Consulting"
+    },
+    {
+      "company_slug": "booz-allen",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/2d/Booz_Allen_Hamilton_logo.svg",
+      "primary_color": "#DA291C",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Consulting"
+    }
+  ]
+}

--- a/supabase/migrations/20260119000005_insert_consulting_themes.sql
+++ b/supabase/migrations/20260119000005_insert_consulting_themes.sql
@@ -1,0 +1,48 @@
+-- Migration: Insert Consulting company themes
+-- Issue: #97 - Expand company themes: Consulting batch
+
+-- Insert or update theme data for Consulting companies
+-- Uses ON CONFLICT to update existing themes
+
+INSERT INTO company_themes (company_slug, logo_url, primary_color, secondary_color, industry_category)
+VALUES
+  -- McKinsey & Company (dark blue brand)
+  ('mckinsey', 'https://upload.wikimedia.org/wikipedia/commons/a/a9/McKinsey_and_Company_Logo_1.svg', '#0033A0', '#1A1A1A', 'Consulting'),
+
+  -- Boston Consulting Group (green brand)
+  ('bcg', 'https://upload.wikimedia.org/wikipedia/commons/e/e7/Boston_Consulting_Group_2020_logo.svg', '#00A651', '#1A1A1A', 'Consulting'),
+
+  -- Bain & Company (red brand)
+  ('bain', 'https://upload.wikimedia.org/wikipedia/commons/9/93/Bain_%26_Company_logo.svg', '#CC0000', '#1A1A1A', 'Consulting'),
+
+  -- Deloitte (green/black brand)
+  ('deloitte', 'https://upload.wikimedia.org/wikipedia/commons/5/56/Deloitte.svg', '#86BC25', '#000000', 'Consulting'),
+
+  -- Accenture (purple brand)
+  ('accenture', 'https://upload.wikimedia.org/wikipedia/commons/c/cd/Accenture.svg', '#A100FF', '#1A1A1A', 'Consulting'),
+
+  -- PwC (orange brand)
+  ('pwc', 'https://upload.wikimedia.org/wikipedia/commons/0/05/PricewaterhouseCoopers_Logo.svg', '#DC6900', '#1A1A1A', 'Consulting'),
+
+  -- EY (yellow/dark brand)
+  ('ey', 'https://upload.wikimedia.org/wikipedia/commons/3/34/EY_logo_2019.svg', '#FFE600', '#2E2E38', 'Consulting'),
+
+  -- KPMG (blue brand)
+  ('kpmg', 'https://upload.wikimedia.org/wikipedia/commons/9/9d/KPMG_logo.svg', '#00338D', '#1A1A1A', 'Consulting'),
+
+  -- Capgemini (blue brand)
+  ('capgemini', 'https://upload.wikimedia.org/wikipedia/commons/9/9d/Capgemini_logo.svg', '#0070AD', '#12ABDB', 'Consulting'),
+
+  -- Booz Allen Hamilton (red brand)
+  ('booz-allen', 'https://upload.wikimedia.org/wikipedia/commons/2/2d/Booz_Allen_Hamilton_logo.svg', '#DA291C', '#1A1A1A', 'Consulting')
+
+ON CONFLICT (company_slug)
+DO UPDATE SET
+  logo_url = EXCLUDED.logo_url,
+  primary_color = EXCLUDED.primary_color,
+  secondary_color = EXCLUDED.secondary_color,
+  industry_category = EXCLUDED.industry_category,
+  updated_at = NOW();
+
+-- Verify the insertions
+-- Expected: 10 companies in Consulting category


### PR DESCRIPTION
## Summary
- Added brand colors and logos for 10 Consulting companies
- Created JSON theme data file: `data/generated/themes/consulting.json`
- Created Supabase migration: `supabase/migrations/20260119000005_insert_consulting_themes.sql`

## Companies Added
- McKinsey & Company (#0033A0 dark blue)
- Boston Consulting Group (#00A651 green)
- Bain & Company (#CC0000 red)
- Deloitte (#86BC25 green)
- Accenture (#A100FF purple)
- PwC (#DC6900 orange)
- EY (#FFE600 yellow)
- KPMG (#00338D blue)
- Capgemini (#0070AD blue)
- Booz Allen Hamilton (#DA291C red)

## Test plan
- [x] JSON file is valid (jq validation)
- [x] All 10 companies have valid hex color codes
- [x] All companies have logo URLs
- [x] npm run lint passes
- [x] npm run type-check passes
- [x] npm run build succeeds
- [x] Theme tests pass (109 tests)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)