### PR TITLE
Add E-commerce/Retail company themes (#98)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -3429,3 +3429,36 @@ All Stage 5 (Launch) code issues are now closed:
   - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
   - Migration uses ON CONFLICT for upsert (updates existing themes)
 
+### 2026-01-18 - Issue #98: Expand company themes: E-commerce/Retail batch
+
+**Completed:**
+- Created Supabase migration for E-commerce/Retail company themes
+- Created JSON theme data file for content loader
+- Added brand colors and logos for 11 E-commerce/Retail companies:
+  - Shopify (#96BF48 green, #5E8E3E dark green)
+  - Etsy (#F56400 orange, #232347 dark)
+  - Wayfair (#7B189F purple, #2B1B4E dark purple)
+  - Chewy (#1C49C2 blue, #FF6D00 orange)
+  - Target (#CC0000 red, #FFFFFF white)
+  - Walmart (#0071CE blue, #FFC220 yellow)
+  - Costco (#E31837 red, #005DAA blue)
+  - Home Depot (#F96302 orange, #1A1A1A black)
+  - Best Buy (#0046BE blue, #FFE000 yellow)
+  - Nike (#000000 black, #FFFFFF white)
+  - Lululemon (#D31334 red, #1A1A1A black)
+
+**Files Created:**
+- `supabase/migrations/20260119000006_insert_ecommerce_retail_themes.sql`
+- `data/generated/themes/e-commerce-retail.json` (11 themes)
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - theme tests pass (109 tests)
+- JSON file validated with jq (11 themes)
+- All acceptance criteria verified:
+  - Theme data for 11 E-commerce/Retail companies
+  - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
+  - Migration uses ON CONFLICT for upsert (updates existing themes)
+

--- a/data/generated/themes/e-commerce-retail.json
+++ b/data/generated/themes/e-commerce-retail.json
@@ -1,0 +1,83 @@
+{
+  "batch": "E-commerce/Retail",
+  "generated_at": "2026-01-18",
+  "themes": [
+    {
+      "company_slug": "shopify",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Shopify_logo_2018.svg",
+      "primary_color": "#96BF48",
+      "secondary_color": "#5E8E3E",
+      "industry_category": "E-commerce/Retail"
+    },
+    {
+      "company_slug": "etsy",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/8/89/Etsy_logo.svg",
+      "primary_color": "#F56400",
+      "secondary_color": "#232347",
+      "industry_category": "E-commerce/Retail"
+    },
+    {
+      "company_slug": "wayfair",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/7/71/Wayfair_logo.svg",
+      "primary_color": "#7B189F",
+      "secondary_color": "#2B1B4E",
+      "industry_category": "E-commerce/Retail"
+    },
+    {
+      "company_slug": "chewy",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/b/bd/Chewy_%28company%29_logo.svg",
+      "primary_color": "#1C49C2",
+      "secondary_color": "#FF6D00",
+      "industry_category": "E-commerce/Retail"
+    },
+    {
+      "company_slug": "target",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/9a/Target_logo.svg",
+      "primary_color": "#CC0000",
+      "secondary_color": "#FFFFFF",
+      "industry_category": "E-commerce/Retail"
+    },
+    {
+      "company_slug": "walmart",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/c/ca/Walmart_logo.svg",
+      "primary_color": "#0071CE",
+      "secondary_color": "#FFC220",
+      "industry_category": "E-commerce/Retail"
+    },
+    {
+      "company_slug": "costco",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/5/59/Costco_Wholesale_logo_2010-10-26.svg",
+      "primary_color": "#E31837",
+      "secondary_color": "#005DAA",
+      "industry_category": "E-commerce/Retail"
+    },
+    {
+      "company_slug": "home-depot",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/5/5f/TheHomeDepot.svg",
+      "primary_color": "#F96302",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "E-commerce/Retail"
+    },
+    {
+      "company_slug": "best-buy",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/f/f5/Best_Buy_Logo.svg",
+      "primary_color": "#0046BE",
+      "secondary_color": "#FFE000",
+      "industry_category": "E-commerce/Retail"
+    },
+    {
+      "company_slug": "nike",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a6/Logo_NIKE.svg",
+      "primary_color": "#000000",
+      "secondary_color": "#FFFFFF",
+      "industry_category": "E-commerce/Retail"
+    },
+    {
+      "company_slug": "lululemon",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/8/8c/Lululemon_Athletica_logo.svg",
+      "primary_color": "#D31334",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "E-commerce/Retail"
+    }
+  ]
+}

--- a/supabase/migrations/20260119000006_insert_ecommerce_retail_themes.sql
+++ b/supabase/migrations/20260119000006_insert_ecommerce_retail_themes.sql
@@ -1,0 +1,51 @@
+-- Migration: Insert E-commerce/Retail company themes
+-- Issue: #98 - Expand company themes: E-commerce/Retail batch
+
+-- Insert or update theme data for E-commerce/Retail companies
+-- Uses ON CONFLICT to update existing themes
+
+INSERT INTO company_themes (company_slug, logo_url, primary_color, secondary_color, industry_category)
+VALUES
+  -- Shopify (green brand)
+  ('shopify', 'https://upload.wikimedia.org/wikipedia/commons/0/0e/Shopify_logo_2018.svg', '#96BF48', '#5E8E3E', 'E-commerce/Retail'),
+
+  -- Etsy (orange brand)
+  ('etsy', 'https://upload.wikimedia.org/wikipedia/commons/8/89/Etsy_logo.svg', '#F56400', '#232347', 'E-commerce/Retail'),
+
+  -- Wayfair (purple brand)
+  ('wayfair', 'https://upload.wikimedia.org/wikipedia/commons/7/71/Wayfair_logo.svg', '#7B189F', '#2B1B4E', 'E-commerce/Retail'),
+
+  -- Chewy (blue/orange brand)
+  ('chewy', 'https://upload.wikimedia.org/wikipedia/commons/b/bd/Chewy_%28company%29_logo.svg', '#1C49C2', '#FF6D00', 'E-commerce/Retail'),
+
+  -- Target (red brand)
+  ('target', 'https://upload.wikimedia.org/wikipedia/commons/9/9a/Target_logo.svg', '#CC0000', '#FFFFFF', 'E-commerce/Retail'),
+
+  -- Walmart (blue/yellow brand)
+  ('walmart', 'https://upload.wikimedia.org/wikipedia/commons/c/ca/Walmart_logo.svg', '#0071CE', '#FFC220', 'E-commerce/Retail'),
+
+  -- Costco (red/blue brand)
+  ('costco', 'https://upload.wikimedia.org/wikipedia/commons/5/59/Costco_Wholesale_logo_2010-10-26.svg', '#E31837', '#005DAA', 'E-commerce/Retail'),
+
+  -- Home Depot (orange brand)
+  ('home-depot', 'https://upload.wikimedia.org/wikipedia/commons/5/5f/TheHomeDepot.svg', '#F96302', '#1A1A1A', 'E-commerce/Retail'),
+
+  -- Best Buy (blue/yellow brand)
+  ('best-buy', 'https://upload.wikimedia.org/wikipedia/commons/f/f5/Best_Buy_Logo.svg', '#0046BE', '#FFE000', 'E-commerce/Retail'),
+
+  -- Nike (black brand)
+  ('nike', 'https://upload.wikimedia.org/wikipedia/commons/a/a6/Logo_NIKE.svg', '#000000', '#FFFFFF', 'E-commerce/Retail'),
+
+  -- Lululemon (red brand)
+  ('lululemon', 'https://upload.wikimedia.org/wikipedia/commons/8/8c/Lululemon_Athletica_logo.svg', '#D31334', '#1A1A1A', 'E-commerce/Retail')
+
+ON CONFLICT (company_slug)
+DO UPDATE SET
+  logo_url = EXCLUDED.logo_url,
+  primary_color = EXCLUDED.primary_color,
+  secondary_color = EXCLUDED.secondary_color,
+  industry_category = EXCLUDED.industry_category,
+  updated_at = NOW();
+
+-- Verify the insertions
+-- Expected: 11 companies in E-commerce/Retail category


### PR DESCRIPTION
## Summary
- Add brand colors and logos for 11 E-commerce/Retail companies
- Created JSON theme data file (`data/generated/themes/e-commerce-retail.json`)
- Created Supabase migration with ON CONFLICT for upsert support

## Companies Added
- Shopify (#96BF48 green, #5E8E3E dark green)
- Etsy (#F56400 orange, #232347 dark)
- Wayfair (#7B189F purple, #2B1B4E dark purple)
- Chewy (#1C49C2 blue, #FF6D00 orange)
- Target (#CC0000 red, #FFFFFF white)
- Walmart (#0071CE blue, #FFC220 yellow)
- Costco (#E31837 red, #005DAA blue)
- Home Depot (#F96302 orange, #1A1A1A black)
- Best Buy (#0046BE blue, #FFE000 yellow)
- Nike (#000000 black, #FFFFFF white)
- Lululemon (#D31334 red, #1A1A1A black)

## Test plan
- [x] JSON file validates with jq (11 themes)
- [x] `npm run lint` passes
- [x] `npm run type-check` passes
- [x] `npm run build` succeeds
- [x] Theme tests pass (109 tests)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)