### PR TITLE
Add Healthcare/Biotech company themes (#99)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -3462,3 +3462,34 @@ All Stage 5 (Launch) code issues are now closed:
   - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
   - Migration uses ON CONFLICT for upsert (updates existing themes)
 
+### 2026-01-19 - Issue #99: Expand company themes: Healthcare/Biotech batch
+
+**Completed:**
+- Created Supabase migration for Healthcare/Biotech company themes
+- Created JSON theme data file for content loader
+- Added brand colors and logos for 10 Healthcare/Biotech companies:
+  - Epic Systems (#E35205 orange, #1A1A1A black)
+  - Cerner (#005DAA blue, #1A1A1A black)
+  - Optum (#FF6200 orange, #002677 blue)
+  - UnitedHealth Group (#002677 blue, #FF6200 orange)
+  - CVS Health (#CC0000 red, #1A1A1A black)
+  - Johnson & Johnson (#D51900 red, #1A1A1A black)
+  - Pfizer (#0093D0 blue, #003B6F dark blue)
+  - Moderna (#007DC5 blue, #00B5E2 cyan)
+  - Illumina (#6CB33F green, #1A1A1A black)
+  - Genentech (#0066B3 blue, #00A9E0 light blue)
+
+**Files Created:**
+- `supabase/migrations/20260119000007_insert_healthcare_biotech_themes.sql`
+- `data/generated/themes/healthcare-biotech.json` (10 themes)
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - theme tests pass (109 tests)
+- JSON file validated with jq (10 themes)
+- All acceptance criteria verified:
+  - Theme data for 10 Healthcare/Biotech companies
+  - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
+  - Migration uses ON CONFLICT for upsert (updates existing themes)

--- a/data/generated/themes/healthcare-biotech.json
+++ b/data/generated/themes/healthcare-biotech.json
@@ -1,0 +1,76 @@
+{
+  "batch": "Healthcare/Biotech",
+  "generated_at": "2026-01-19",
+  "themes": [
+    {
+      "company_slug": "epic",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/24/Epic_Systems.svg",
+      "primary_color": "#E35205",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Healthcare/Biotech"
+    },
+    {
+      "company_slug": "cerner",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/8/8c/Cerner_logo.svg",
+      "primary_color": "#005DAA",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Healthcare/Biotech"
+    },
+    {
+      "company_slug": "optum",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/23/Optum_logo_2021.svg",
+      "primary_color": "#FF6200",
+      "secondary_color": "#002677",
+      "industry_category": "Healthcare/Biotech"
+    },
+    {
+      "company_slug": "unitedhealth",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/6/63/UnitedHealth_Group_logo.svg",
+      "primary_color": "#002677",
+      "secondary_color": "#FF6200",
+      "industry_category": "Healthcare/Biotech"
+    },
+    {
+      "company_slug": "cvs",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/6/69/CVS_Health_Logo.svg",
+      "primary_color": "#CC0000",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Healthcare/Biotech"
+    },
+    {
+      "company_slug": "johnson-johnson",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/2/22/Johnson_and_Johnson_logo.svg",
+      "primary_color": "#D51900",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Healthcare/Biotech"
+    },
+    {
+      "company_slug": "pfizer",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/8/8c/Pfizer_%282021%29.svg",
+      "primary_color": "#0093D0",
+      "secondary_color": "#003B6F",
+      "industry_category": "Healthcare/Biotech"
+    },
+    {
+      "company_slug": "moderna",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/e/e0/Moderna_logo.svg",
+      "primary_color": "#007DC5",
+      "secondary_color": "#00B5E2",
+      "industry_category": "Healthcare/Biotech"
+    },
+    {
+      "company_slug": "illumina",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a1/Illumina_logo.svg",
+      "primary_color": "#6CB33F",
+      "secondary_color": "#1A1A1A",
+      "industry_category": "Healthcare/Biotech"
+    },
+    {
+      "company_slug": "genentech",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/e/e7/Genentech_Logo.svg",
+      "primary_color": "#0066B3",
+      "secondary_color": "#00A9E0",
+      "industry_category": "Healthcare/Biotech"
+    }
+  ]
+}

--- a/supabase/migrations/20260119000007_insert_healthcare_biotech_themes.sql
+++ b/supabase/migrations/20260119000007_insert_healthcare_biotech_themes.sql
@@ -1,0 +1,48 @@
+-- Migration: Insert Healthcare/Biotech company themes
+-- Issue: #99 - Expand company themes: Healthcare/Biotech batch
+
+-- Insert or update theme data for Healthcare/Biotech companies
+-- Uses ON CONFLICT to update existing themes
+
+INSERT INTO company_themes (company_slug, logo_url, primary_color, secondary_color, industry_category)
+VALUES
+  -- Epic Systems (orange/red brand)
+  ('epic', 'https://upload.wikimedia.org/wikipedia/commons/2/24/Epic_Systems.svg', '#E35205', '#1A1A1A', 'Healthcare/Biotech'),
+
+  -- Cerner (blue brand - now Oracle Health)
+  ('cerner', 'https://upload.wikimedia.org/wikipedia/commons/8/8c/Cerner_logo.svg', '#005DAA', '#1A1A1A', 'Healthcare/Biotech'),
+
+  -- Optum (orange brand)
+  ('optum', 'https://upload.wikimedia.org/wikipedia/commons/2/23/Optum_logo_2021.svg', '#FF6200', '#002677', 'Healthcare/Biotech'),
+
+  -- UnitedHealth Group (blue brand)
+  ('unitedhealth', 'https://upload.wikimedia.org/wikipedia/commons/6/63/UnitedHealth_Group_logo.svg', '#002677', '#FF6200', 'Healthcare/Biotech'),
+
+  -- CVS Health (red brand)
+  ('cvs', 'https://upload.wikimedia.org/wikipedia/commons/6/69/CVS_Health_Logo.svg', '#CC0000', '#1A1A1A', 'Healthcare/Biotech'),
+
+  -- Johnson & Johnson (red brand)
+  ('johnson-johnson', 'https://upload.wikimedia.org/wikipedia/commons/2/22/Johnson_and_Johnson_logo.svg', '#D51900', '#1A1A1A', 'Healthcare/Biotech'),
+
+  -- Pfizer (blue brand)
+  ('pfizer', 'https://upload.wikimedia.org/wikipedia/commons/8/8c/Pfizer_%282021%29.svg', '#0093D0', '#003B6F', 'Healthcare/Biotech'),
+
+  -- Moderna (blue/cyan brand)
+  ('moderna', 'https://upload.wikimedia.org/wikipedia/commons/e/e0/Moderna_logo.svg', '#007DC5', '#00B5E2', 'Healthcare/Biotech'),
+
+  -- Illumina (green brand)
+  ('illumina', 'https://upload.wikimedia.org/wikipedia/commons/a/a1/Illumina_logo.svg', '#6CB33F', '#1A1A1A', 'Healthcare/Biotech'),
+
+  -- Genentech (blue brand - Roche subsidiary)
+  ('genentech', 'https://upload.wikimedia.org/wikipedia/commons/e/e7/Genentech_Logo.svg', '#0066B3', '#00A9E0', 'Healthcare/Biotech')
+
+ON CONFLICT (company_slug)
+DO UPDATE SET
+  logo_url = EXCLUDED.logo_url,
+  primary_color = EXCLUDED.primary_color,
+  secondary_color = EXCLUDED.secondary_color,
+  industry_category = EXCLUDED.industry_category,
+  updated_at = NOW();
+
+-- Verify the insertions
+-- Expected: 10 companies in Healthcare/Biotech category


### PR DESCRIPTION
## Summary
- Add Supabase migration for 10 Healthcare/Biotech company themes
- Create JSON theme data file for content loader
- Companies: Epic, Cerner, Optum, UnitedHealth, CVS, J&J, Pfizer, Moderna, Illumina, Genentech

## Changes
- New migration: `supabase/migrations/20260119000007_insert_healthcare_biotech_themes.sql`
- New JSON: `data/generated/themes/healthcare-biotech.json` (10 themes)
- Updated `activity.md` with progress

## Test plan
- [x] Lint passes
- [x] Type-check passes
- [x] Build succeeds
- [x] Theme tests pass (109 tests)
- [x] JSON file validated with jq

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)