### PR TITLE
Add Enterprise SaaS company themes (#100)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -3493,3 +3493,39 @@ All Stage 5 (Launch) code issues are now closed:
   - Theme data for 10 Healthcare/Biotech companies
   - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
   - Migration uses ON CONFLICT for upsert (updates existing themes)
+
+### 2026-01-18 - Issue #100: Expand company themes: Enterprise SaaS batch
+
+**Completed:**
+- Created Supabase migration for Enterprise SaaS company themes
+- Created JSON theme data file for content loader
+- Added brand colors and logos for 14 Enterprise SaaS companies:
+  - Salesforce (#00a1e0 blue, #032d60 dark blue)
+  - Oracle (#f80000 red, #312d2a dark)
+  - SAP (#0070f2 blue, #354a5f dark)
+  - Workday (#f6851f orange, #005cb9 blue)
+  - ServiceNow (#81b5a1 green, #293e40 dark)
+  - Atlassian (#0052cc blue, #172b4d dark)
+  - Splunk (#65a637 green, #000000 black)
+  - Twilio (#f22f46 red, #0d122b dark)
+  - HubSpot (#ff7a59 orange, #33475b dark)
+  - Zendesk (#03363d dark, #78a300 green)
+  - Okta (#007dc1 blue, #1a1a1a black)
+  - Cloudflare (#f38020 orange, #404040 gray)
+  - MongoDB (#00ed64 green, #001e2b dark)
+  - Elastic (#fed10a yellow, #343741 dark)
+
+**Files Created:**
+- `supabase/migrations/20260119000008_insert_enterprise_saas_themes.sql`
+- `data/generated/themes/enterprise-saas.json` (14 themes)
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - theme tests pass (109 tests)
+- JSON file validated with jq (14 themes)
+- All acceptance criteria verified:
+  - Theme data for 14 Enterprise SaaS companies
+  - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
+  - Migration uses ON CONFLICT for upsert (updates existing themes)

--- a/data/generated/themes/enterprise-saas.json
+++ b/data/generated/themes/enterprise-saas.json
@@ -1,0 +1,104 @@
+{
+  "batch": "Enterprise SaaS",
+  "generated_at": "2026-01-18",
+  "themes": [
+    {
+      "company_slug": "salesforce",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/f/f9/Salesforce.com_logo.svg",
+      "primary_color": "#00a1e0",
+      "secondary_color": "#032d60",
+      "industry_category": "Enterprise SaaS"
+    },
+    {
+      "company_slug": "oracle",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/5/50/Oracle_logo.svg",
+      "primary_color": "#f80000",
+      "secondary_color": "#312d2a",
+      "industry_category": "Enterprise SaaS"
+    },
+    {
+      "company_slug": "sap",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg",
+      "primary_color": "#0070f2",
+      "secondary_color": "#354a5f",
+      "industry_category": "Enterprise SaaS"
+    },
+    {
+      "company_slug": "workday",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/8/80/Workday_logo.svg",
+      "primary_color": "#f6851f",
+      "secondary_color": "#005cb9",
+      "industry_category": "Enterprise SaaS"
+    },
+    {
+      "company_slug": "servicenow",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/5/57/ServiceNow_logo.svg",
+      "primary_color": "#81b5a1",
+      "secondary_color": "#293e40",
+      "industry_category": "Enterprise SaaS"
+    },
+    {
+      "company_slug": "atlassian",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/9e/Atlassian_Logo.svg",
+      "primary_color": "#0052cc",
+      "secondary_color": "#172b4d",
+      "industry_category": "Enterprise SaaS"
+    },
+    {
+      "company_slug": "splunk",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/e/e8/Splunk-Logo.svg",
+      "primary_color": "#65a637",
+      "secondary_color": "#000000",
+      "industry_category": "Enterprise SaaS"
+    },
+    {
+      "company_slug": "twilio",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/7/7e/Twilio-logo-red.svg",
+      "primary_color": "#f22f46",
+      "secondary_color": "#0d122b",
+      "industry_category": "Enterprise SaaS"
+    },
+    {
+      "company_slug": "hubspot",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/3/3f/HubSpot_Logo.svg",
+      "primary_color": "#ff7a59",
+      "secondary_color": "#33475b",
+      "industry_category": "Enterprise SaaS"
+    },
+    {
+      "company_slug": "zendesk",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/c/c8/Zendesk_logo.svg",
+      "primary_color": "#03363d",
+      "secondary_color": "#78a300",
+      "industry_category": "Enterprise SaaS"
+    },
+    {
+      "company_slug": "okta",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a0/Okta_logo.svg",
+      "primary_color": "#007dc1",
+      "secondary_color": "#1a1a1a",
+      "industry_category": "Enterprise SaaS"
+    },
+    {
+      "company_slug": "cloudflare",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/4/4b/Cloudflare_Logo.svg",
+      "primary_color": "#f38020",
+      "secondary_color": "#404040",
+      "industry_category": "Enterprise SaaS"
+    },
+    {
+      "company_slug": "mongodb",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/9/93/MongoDB_Logo.svg",
+      "primary_color": "#00ed64",
+      "secondary_color": "#001e2b",
+      "industry_category": "Enterprise SaaS"
+    },
+    {
+      "company_slug": "elastic",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/f/f4/Elasticsearch_logo.svg",
+      "primary_color": "#fed10a",
+      "secondary_color": "#343741",
+      "industry_category": "Enterprise SaaS"
+    }
+  ]
+}

--- a/supabase/migrations/20260119000008_insert_enterprise_saas_themes.sql
+++ b/supabase/migrations/20260119000008_insert_enterprise_saas_themes.sql
@@ -1,0 +1,60 @@
+-- Migration: Insert Enterprise SaaS company themes
+-- Issue: #100 - Expand company themes: Enterprise SaaS batch
+
+-- Insert or update theme data for Enterprise SaaS companies
+-- Uses ON CONFLICT to update existing themes
+
+INSERT INTO company_themes (company_slug, logo_url, primary_color, secondary_color, industry_category)
+VALUES
+  -- Salesforce
+  ('salesforce', 'https://upload.wikimedia.org/wikipedia/commons/f/f9/Salesforce.com_logo.svg', '#00a1e0', '#032d60', 'Enterprise SaaS'),
+
+  -- Oracle
+  ('oracle', 'https://upload.wikimedia.org/wikipedia/commons/5/50/Oracle_logo.svg', '#f80000', '#312d2a', 'Enterprise SaaS'),
+
+  -- SAP
+  ('sap', 'https://upload.wikimedia.org/wikipedia/commons/5/59/SAP_2011_logo.svg', '#0070f2', '#354a5f', 'Enterprise SaaS'),
+
+  -- Workday
+  ('workday', 'https://upload.wikimedia.org/wikipedia/commons/8/80/Workday_logo.svg', '#f6851f', '#005cb9', 'Enterprise SaaS'),
+
+  -- ServiceNow
+  ('servicenow', 'https://upload.wikimedia.org/wikipedia/commons/5/57/ServiceNow_logo.svg', '#81b5a1', '#293e40', 'Enterprise SaaS'),
+
+  -- Atlassian
+  ('atlassian', 'https://upload.wikimedia.org/wikipedia/commons/9/9e/Atlassian_Logo.svg', '#0052cc', '#172b4d', 'Enterprise SaaS'),
+
+  -- Splunk
+  ('splunk', 'https://upload.wikimedia.org/wikipedia/commons/e/e8/Splunk-Logo.svg', '#65a637', '#000000', 'Enterprise SaaS'),
+
+  -- Twilio
+  ('twilio', 'https://upload.wikimedia.org/wikipedia/commons/7/7e/Twilio-logo-red.svg', '#f22f46', '#0d122b', 'Enterprise SaaS'),
+
+  -- HubSpot
+  ('hubspot', 'https://upload.wikimedia.org/wikipedia/commons/3/3f/HubSpot_Logo.svg', '#ff7a59', '#33475b', 'Enterprise SaaS'),
+
+  -- Zendesk
+  ('zendesk', 'https://upload.wikimedia.org/wikipedia/commons/c/c8/Zendesk_logo.svg', '#03363d', '#78a300', 'Enterprise SaaS'),
+
+  -- Okta
+  ('okta', 'https://upload.wikimedia.org/wikipedia/commons/a/a0/Okta_logo.svg', '#007dc1', '#1a1a1a', 'Enterprise SaaS'),
+
+  -- Cloudflare
+  ('cloudflare', 'https://upload.wikimedia.org/wikipedia/commons/4/4b/Cloudflare_Logo.svg', '#f38020', '#404040', 'Enterprise SaaS'),
+
+  -- MongoDB
+  ('mongodb', 'https://upload.wikimedia.org/wikipedia/commons/9/93/MongoDB_Logo.svg', '#00ed64', '#001e2b', 'Enterprise SaaS'),
+
+  -- Elastic
+  ('elastic', 'https://upload.wikimedia.org/wikipedia/commons/f/f4/Elasticsearch_logo.svg', '#fed10a', '#343741', 'Enterprise SaaS')
+
+ON CONFLICT (company_slug)
+DO UPDATE SET
+  logo_url = EXCLUDED.logo_url,
+  primary_color = EXCLUDED.primary_color,
+  secondary_color = EXCLUDED.secondary_color,
+  industry_category = EXCLUDED.industry_category,
+  updated_at = NOW();
+
+-- Verify the insertions
+-- Expected: 14 companies in Enterprise SaaS category


### PR DESCRIPTION
## Summary
- Add brand colors and logos for 14 Enterprise SaaS companies
- Created JSON theme data file: `data/generated/themes/enterprise-saas.json`
- Created Supabase migration: `supabase/migrations/20260119000008_insert_enterprise_saas_themes.sql`

## Companies Added
Salesforce, Oracle, SAP, Workday, ServiceNow, Atlassian, Splunk, Twilio, HubSpot, Zendesk, Okta, Cloudflare, MongoDB, Elastic

## Test plan
- [x] `npm run lint` - passes with no errors
- [x] `npm run type-check` - passes with no errors
- [x] `npm run build` - successful production build
- [x] `npm test` - theme tests pass (109 tests)
- [x] JSON file validated with jq (14 themes)

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)