### PR TITLE
Add Media/Entertainment company themes (#101)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -3529,3 +3529,37 @@ All Stage 5 (Launch) code issues are now closed:
   - Theme data for 14 Enterprise SaaS companies
   - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
   - Migration uses ON CONFLICT for upsert (updates existing themes)
+
+### 2026-01-18 - Issue #101: Expand company themes: Media/Entertainment batch
+
+**Completed:**
+- Created Supabase migration for Media/Entertainment company themes
+- Created JSON theme data file for content loader
+- Added brand colors and logos for 12 Media/Entertainment companies:
+  - Disney (#113ccf blue, #0063e5 blue)
+  - Warner Bros Discovery (#0047bb blue, #1a1a1a black)
+  - Spotify (#1db954 green, #191414 dark)
+  - TikTok (#fe2c55 red, #25f4ee cyan)
+  - Snap (#fffc00 yellow, #000000 black)
+  - Pinterest (#e60023 red, #efefef gray)
+  - Reddit (#ff4500 orange, #1a1a1b dark)
+  - LinkedIn (#0a66c2 blue, #000000 black)
+  - X (#000000 black, #ffffff white)
+  - Electronic Arts (#ff4747 red, #000000 black)
+  - Activision Blizzard (#3c3c3c gray, #00aeff blue)
+  - Roblox (#e1061b red, #000000 black)
+
+**Files Created:**
+- `supabase/migrations/20260119000009_insert_media_entertainment_themes.sql`
+- `data/generated/themes/media-entertainment.json` (12 themes)
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - theme tests pass (109 tests)
+- JSON file validated with jq (12 themes)
+- All acceptance criteria verified:
+  - Theme data for 12 Media/Entertainment companies
+  - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
+  - Migration uses ON CONFLICT for upsert (updates existing themes)

--- a/data/generated/themes/media-entertainment.json
+++ b/data/generated/themes/media-entertainment.json
@@ -1,0 +1,90 @@
+{
+  "batch": "Media/Entertainment",
+  "generated_at": "2026-01-19",
+  "themes": [
+    {
+      "company_slug": "disney",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/3/3e/Disney%2B_logo.svg",
+      "primary_color": "#113ccf",
+      "secondary_color": "#0063e5",
+      "industry_category": "Media/Entertainment"
+    },
+    {
+      "company_slug": "wbd",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/a/a6/Warner_Bros._Discovery_wordmark.svg",
+      "primary_color": "#0047bb",
+      "secondary_color": "#1a1a1a",
+      "industry_category": "Media/Entertainment"
+    },
+    {
+      "company_slug": "spotify",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/8/84/Spotify_icon.svg",
+      "primary_color": "#1db954",
+      "secondary_color": "#191414",
+      "industry_category": "Media/Entertainment"
+    },
+    {
+      "company_slug": "tiktok",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/en/a/a9/TikTok_logo.svg",
+      "primary_color": "#fe2c55",
+      "secondary_color": "#25f4ee",
+      "industry_category": "Media/Entertainment"
+    },
+    {
+      "company_slug": "snap",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/en/a/ad/Snap_Inc._logo.svg",
+      "primary_color": "#fffc00",
+      "secondary_color": "#000000",
+      "industry_category": "Media/Entertainment"
+    },
+    {
+      "company_slug": "pinterest",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/0/08/Pinterest-logo.png",
+      "primary_color": "#e60023",
+      "secondary_color": "#efefef",
+      "industry_category": "Media/Entertainment"
+    },
+    {
+      "company_slug": "reddit",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/b/b4/Reddit_logo.svg",
+      "primary_color": "#ff4500",
+      "secondary_color": "#1a1a1b",
+      "industry_category": "Media/Entertainment"
+    },
+    {
+      "company_slug": "linkedin",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/c/ca/LinkedIn_logo_initials.png",
+      "primary_color": "#0a66c2",
+      "secondary_color": "#000000",
+      "industry_category": "Media/Entertainment"
+    },
+    {
+      "company_slug": "x",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/5/5a/X_icon_2.svg",
+      "primary_color": "#000000",
+      "secondary_color": "#ffffff",
+      "industry_category": "Media/Entertainment"
+    },
+    {
+      "company_slug": "ea",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/0/0d/Electronic-Arts-Logo.svg",
+      "primary_color": "#ff4747",
+      "secondary_color": "#000000",
+      "industry_category": "Media/Entertainment"
+    },
+    {
+      "company_slug": "activision-blizzard",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/f/fa/Activision_Blizzard_wordmark.svg",
+      "primary_color": "#3c3c3c",
+      "secondary_color": "#00aeff",
+      "industry_category": "Media/Entertainment"
+    },
+    {
+      "company_slug": "roblox",
+      "logo_url": "https://upload.wikimedia.org/wikipedia/commons/3/3a/Roblox_player_icon_black.svg",
+      "primary_color": "#e1061b",
+      "secondary_color": "#000000",
+      "industry_category": "Media/Entertainment"
+    }
+  ]
+}

--- a/supabase/migrations/20260119000009_insert_media_entertainment_themes.sql
+++ b/supabase/migrations/20260119000009_insert_media_entertainment_themes.sql
@@ -1,0 +1,54 @@
+-- Migration: Insert Media/Entertainment company themes
+-- Issue: #101 - Expand company themes: Media/Entertainment batch
+
+-- Insert or update theme data for Media/Entertainment companies
+-- Uses ON CONFLICT to update existing themes
+
+INSERT INTO company_themes (company_slug, logo_url, primary_color, secondary_color, industry_category)
+VALUES
+  -- Disney
+  ('disney', 'https://upload.wikimedia.org/wikipedia/commons/3/3e/Disney%2B_logo.svg', '#113ccf', '#0063e5', 'Media/Entertainment'),
+
+  -- Warner Bros Discovery
+  ('wbd', 'https://upload.wikimedia.org/wikipedia/commons/a/a6/Warner_Bros._Discovery_wordmark.svg', '#0047bb', '#1a1a1a', 'Media/Entertainment'),
+
+  -- Spotify
+  ('spotify', 'https://upload.wikimedia.org/wikipedia/commons/8/84/Spotify_icon.svg', '#1db954', '#191414', 'Media/Entertainment'),
+
+  -- TikTok
+  ('tiktok', 'https://upload.wikimedia.org/wikipedia/en/a/a9/TikTok_logo.svg', '#fe2c55', '#25f4ee', 'Media/Entertainment'),
+
+  -- Snap
+  ('snap', 'https://upload.wikimedia.org/wikipedia/en/a/ad/Snap_Inc._logo.svg', '#fffc00', '#000000', 'Media/Entertainment'),
+
+  -- Pinterest
+  ('pinterest', 'https://upload.wikimedia.org/wikipedia/commons/0/08/Pinterest-logo.png', '#e60023', '#efefef', 'Media/Entertainment'),
+
+  -- Reddit
+  ('reddit', 'https://upload.wikimedia.org/wikipedia/commons/b/b4/Reddit_logo.svg', '#ff4500', '#1a1a1b', 'Media/Entertainment'),
+
+  -- LinkedIn
+  ('linkedin', 'https://upload.wikimedia.org/wikipedia/commons/c/ca/LinkedIn_logo_initials.png', '#0a66c2', '#000000', 'Media/Entertainment'),
+
+  -- X (formerly Twitter)
+  ('x', 'https://upload.wikimedia.org/wikipedia/commons/5/5a/X_icon_2.svg', '#000000', '#ffffff', 'Media/Entertainment'),
+
+  -- Electronic Arts
+  ('ea', 'https://upload.wikimedia.org/wikipedia/commons/0/0d/Electronic-Arts-Logo.svg', '#ff4747', '#000000', 'Media/Entertainment'),
+
+  -- Activision Blizzard
+  ('activision-blizzard', 'https://upload.wikimedia.org/wikipedia/commons/f/fa/Activision_Blizzard_wordmark.svg', '#3c3c3c', '#00aeff', 'Media/Entertainment'),
+
+  -- Roblox
+  ('roblox', 'https://upload.wikimedia.org/wikipedia/commons/3/3a/Roblox_player_icon_black.svg', '#e1061b', '#000000', 'Media/Entertainment')
+
+ON CONFLICT (company_slug)
+DO UPDATE SET
+  logo_url = EXCLUDED.logo_url,
+  primary_color = EXCLUDED.primary_color,
+  secondary_color = EXCLUDED.secondary_color,
+  industry_category = EXCLUDED.industry_category,
+  updated_at = NOW();
+
+-- Verify the insertions
+-- Expected: 12 companies in Media/Entertainment category


### PR DESCRIPTION
## Summary
- Add brand colors and logos for 12 Media/Entertainment companies
- Create Supabase migration for theme data
- Create JSON theme data file for content loader

## Companies Added
Disney, Warner Bros Discovery, Spotify, TikTok, Snap, Pinterest, Reddit, LinkedIn, X, Electronic Arts, Activision Blizzard, Roblox

## Test plan
- [x] `npm run lint` passes
- [x] `npm run type-check` passes
- [x] `npm run build` passes
- [x] Theme tests pass (109 tests)
- [x] JSON file validated with jq

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)