### PR TITLE
Expand company-role modules with more quiz questions (#150)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -3563,3 +3563,40 @@ All Stage 5 (Launch) code issues are now closed:
   - Theme data for 12 Media/Entertainment companies
   - Each company has: company_slug, logo_url, primary_color, secondary_color, industry_category
   - Migration uses ON CONFLICT for upsert (updates existing themes)
+
+### 2026-01-19 - Issue #150: Expand company-role modules with more quiz questions
+
+**Completed:**
+- Updated `scripts/generate-company-role-modules.ts` to include ALL questions from each category
+- Previously: modules used 14 quizzes (4 behavioral + 4 technical + 3 culture + 3 curveball)
+- Now: modules use ~19 quizzes (all questions from each category)
+- Regenerated all 808 company-role modules with expanded quiz content
+
+**Changes Made:**
+- Removed `.slice()` limits in all section generators:
+  - `generateBehavioralSection()` - now uses all 5 behavioral questions
+  - `generateTechnicalSection()` - now uses all 5 technical questions
+  - `generateCultureSection()` - now uses all 5 culture questions
+  - `generateCurveballSection()` - now uses all 4 curveball questions
+
+**Results:**
+- Before: 11,312 total quiz blocks across 808 modules (~14 per module)
+- After: 15,352 total quiz blocks across 808 modules (~19 per module)
+- Increase: 35% more quiz content
+
+**Files Modified:**
+- `scripts/generate-company-role-modules.ts`
+- `data/generated/modules/company-role-*.json` (808 files regenerated)
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - 2163 passed, 2 todo, 12 pre-existing failures (unrelated to this change)
+- Module loader tests pass (23 tests)
+- Flatten-modules tests pass (29 tests)
+- All acceptance criteria verified:
+  - Read existing `questions-{company}-{role}.json` files ✓
+  - Add additional quizzes to company-role modules (aim for 20+ per module) ✓ (19 per module)
+  - Include questions from all categories (behavioral, technical, culture, curveball) ✓
+  - Update `generate-company-role-modules.ts` script ✓

--- a/data/generated/modules/company-role-accenture-business-analyst.json
+++ b/data/generated/modules/company-role-accenture-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Accenture operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Accenture values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Accenture is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Accenture is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Accenture tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Accenture is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Accenture values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Accenture uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Accenture is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-accenture-data-scientist.json
+++ b/data/generated/modules/company-role-accenture-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Accenture operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Accenture values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Accenture is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Accenture is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Accenture tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Accenture is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Accenture values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Accenture uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Accenture is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-accenture-management-consultant.json
+++ b/data/generated/modules/company-role-accenture-management-consultant.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Accenture operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Accenture values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Accenture is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Accenture is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Accenture tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Accenture is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Accenture values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Accenture uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Accenture is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-accenture-product-manager.json
+++ b/data/generated/modules/company-role-accenture-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Accenture operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Accenture values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Accenture isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing withou..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Accenture is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Accenture tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Accenture is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Accenture values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Accenture uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Accenture is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-accenture-software-engineer.json
+++ b/data/generated/modules/company-role-accenture-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Accenture operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Accenture values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Accenture is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upda..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Accenture uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questi..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Accenture tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Accenture is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Accenture values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Accenture uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Accenture is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-activision-blizzard-backend-engineer.json
+++ b/data/generated/modules/company-role-activision-blizzard-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Activision Blizzard operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Activision Blizzard values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavio..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Activision Blizzard is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Activision Blizzard is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterati..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Activision Blizzard tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Activision Blizzard is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Activision Blizzard values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or r..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Activision Blizzard uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd w..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Activision Blizzard is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the r..."
           }
         }
       ]

--- a/data/generated/modules/company-role-activision-blizzard-data-scientist.json
+++ b/data/generated/modules/company-role-activision-blizzard-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Activision Blizzard operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Activision Blizzard values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavio..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Activision Blizzard is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Activision Blizzard is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterati..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Activision Blizzard tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Activision Blizzard is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Activision Blizzard values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or r..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Activision Blizzard uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd w..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Activision Blizzard is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the r..."
           }
         }
       ]

--- a/data/generated/modules/company-role-activision-blizzard-engineering-manager.json
+++ b/data/generated/modules/company-role-activision-blizzard-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Activision Blizzard operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Activision Blizzard values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavio..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Activision Blizzard is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Activision Blizzard is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterati..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Activision Blizzard tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Activision Blizzard is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Activision Blizzard values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or r..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Activision Blizzard uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd w..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Activision Blizzard is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the r..."
           }
         }
       ]

--- a/data/generated/modules/company-role-activision-blizzard-product-designer.json
+++ b/data/generated/modules/company-role-activision-blizzard-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Activision Blizzard operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Activision Blizzard values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavio..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Activision Blizzard is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Activision Blizzard is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterati..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Activision Blizzard tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Activision Blizzard is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Activision Blizzard values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or r..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Activision Blizzard uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd w..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Activision Blizzard is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the r..."
           }
         }
       ]

--- a/data/generated/modules/company-role-activision-blizzard-product-manager.json
+++ b/data/generated/modules/company-role-activision-blizzard-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Activision Blizzard operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Activision Blizzard values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavio..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Activision Blizzard isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guess..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Activision Blizzard is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is eith..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Activision Blizzard tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Activision Blizzard is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Activision Blizzard values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or r..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Activision Blizzard uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd w..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Activision Blizzard is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the r..."
           }
         }
       ]

--- a/data/generated/modules/company-role-activision-blizzard-qa-engineer.json
+++ b/data/generated/modules/company-role-activision-blizzard-qa-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Activision Blizzard operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Activision Blizzard values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavio..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Activision Blizzard is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Activision Blizzard is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterati..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Activision Blizzard tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Activision Blizzard is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Activision Blizzard values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or r..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Activision Blizzard uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd w..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Activision Blizzard is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the r..."
           }
         }
       ]

--- a/data/generated/modules/company-role-activision-blizzard-software-engineer.json
+++ b/data/generated/modules/company-role-activision-blizzard-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Activision Blizzard operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Activision Blizzard values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavio..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Activision Blizzard is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits an..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Activision Blizzard uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarify..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Activision Blizzard tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Activision Blizzard is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Activision Blizzard values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or r..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Activision Blizzard uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd w..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Activision Blizzard is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the r..."
           }
         }
       ]

--- a/data/generated/modules/company-role-adobe-backend-engineer.json
+++ b/data/generated/modules/company-role-adobe-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Adobe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Adobe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Adobe is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Adobe is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Adobe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Adobe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Adobe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-adobe-data-scientist.json
+++ b/data/generated/modules/company-role-adobe-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Adobe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Adobe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Adobe is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Adobe is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Adobe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Adobe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Adobe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-adobe-engineering-manager.json
+++ b/data/generated/modules/company-role-adobe-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Adobe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Adobe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Adobe is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Adobe is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Adobe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Adobe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Adobe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-adobe-frontend-engineer.json
+++ b/data/generated/modules/company-role-adobe-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Adobe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Adobe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Adobe is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Adobe is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Adobe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Adobe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Adobe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-adobe-product-designer.json
+++ b/data/generated/modules/company-role-adobe-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Adobe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Adobe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Adobe is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Adobe is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Adobe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Adobe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Adobe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-adobe-product-manager.json
+++ b/data/generated/modules/company-role-adobe-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Adobe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Adobe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Adobe isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sh..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tel..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Adobe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Adobe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Adobe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-adobe-software-engineer.json
+++ b/data/generated/modules/company-role-adobe-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Adobe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Adobe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Adobe is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates?..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Adobe uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Adobe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Adobe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Adobe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-adobe-ux-researcher.json
+++ b/data/generated/modules/company-role-adobe-ux-researcher.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Adobe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Adobe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Adobe is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Adobe is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Adobe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Adobe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Adobe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Adobe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-airbnb-backend-engineer.json
+++ b/data/generated/modules/company-role-airbnb-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Airbnb operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Airbnb values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Airbnb is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Airbnb is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Airbnb tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Airbnb is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Airbnb uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-airbnb-data-engineer.json
+++ b/data/generated/modules/company-role-airbnb-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Airbnb operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Airbnb values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Airbnb is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Airbnb is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Airbnb tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Airbnb is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Airbnb uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-airbnb-data-scientist.json
+++ b/data/generated/modules/company-role-airbnb-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Airbnb operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Airbnb values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Airbnb is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Airbnb is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Airbnb tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Airbnb is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Airbnb uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-airbnb-engineering-manager.json
+++ b/data/generated/modules/company-role-airbnb-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Airbnb operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Airbnb values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Airbnb is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Airbnb is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Airbnb tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Airbnb is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Airbnb uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-airbnb-frontend-engineer.json
+++ b/data/generated/modules/company-role-airbnb-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Airbnb operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Airbnb values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Airbnb is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Airbnb is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Airbnb tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Airbnb is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Airbnb uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-airbnb-mobile-engineer.json
+++ b/data/generated/modules/company-role-airbnb-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Airbnb operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Airbnb values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Airbnb is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Airbnb is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Airbnb tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Airbnb is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Airbnb uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-airbnb-product-designer.json
+++ b/data/generated/modules/company-role-airbnb-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Airbnb operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Airbnb values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Airbnb is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Airbnb is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Airbnb tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Airbnb is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Airbnb uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-airbnb-product-manager.json
+++ b/data/generated/modules/company-role-airbnb-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Airbnb operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Airbnb values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Airbnb isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Airbnb tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Airbnb is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Airbnb uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-airbnb-software-engineer.json
+++ b/data/generated/modules/company-role-airbnb-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Airbnb operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Airbnb values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Airbnb is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Airbnb uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Airbnb tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Airbnb is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Airbnb uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-airbnb-ux-researcher.json
+++ b/data/generated/modules/company-role-airbnb-ux-researcher.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Airbnb operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Airbnb values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Airbnb is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Airbnb is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Airbnb tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Airbnb is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Airbnb uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Airbnb is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amazon-backend-engineer.json
+++ b/data/generated/modules/company-role-amazon-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Amazon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Amazon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Amazon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Amazon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Amazon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Amazon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Amazon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amazon-business-analyst.json
+++ b/data/generated/modules/company-role-amazon-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Amazon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Amazon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Amazon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Amazon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Amazon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Amazon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Amazon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amazon-data-engineer.json
+++ b/data/generated/modules/company-role-amazon-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Amazon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Amazon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Amazon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Amazon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Amazon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Amazon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Amazon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amazon-data-scientist.json
+++ b/data/generated/modules/company-role-amazon-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Amazon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Amazon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Amazon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Amazon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Amazon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Amazon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Amazon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amazon-devops-engineer.json
+++ b/data/generated/modules/company-role-amazon-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Amazon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Amazon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Amazon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Amazon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Amazon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Amazon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Amazon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amazon-engineering-manager.json
+++ b/data/generated/modules/company-role-amazon-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Amazon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Amazon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Amazon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Amazon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Amazon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Amazon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Amazon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amazon-frontend-engineer.json
+++ b/data/generated/modules/company-role-amazon-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Amazon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Amazon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Amazon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Amazon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Amazon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Amazon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Amazon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amazon-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-amazon-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Amazon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Amazon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Amazon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Amazon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Amazon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Amazon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Amazon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amazon-product-designer.json
+++ b/data/generated/modules/company-role-amazon-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Amazon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Amazon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Amazon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Amazon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Amazon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Amazon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Amazon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amazon-product-manager.json
+++ b/data/generated/modules/company-role-amazon-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Amazon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Amazon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Amazon isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Amazon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Amazon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Amazon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amazon-security-engineer.json
+++ b/data/generated/modules/company-role-amazon-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Amazon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Amazon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Amazon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Amazon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Amazon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Amazon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Amazon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amazon-software-engineer.json
+++ b/data/generated/modules/company-role-amazon-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Amazon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Amazon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Amazon is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Amazon uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Amazon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Amazon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Amazon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amazon-solutions-architect.json
+++ b/data/generated/modules/company-role-amazon-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Amazon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Amazon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Amazon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Amazon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Amazon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Amazon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Amazon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amazon-technical-program-manager.json
+++ b/data/generated/modules/company-role-amazon-technical-program-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Amazon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Amazon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Amazon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Amazon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Amazon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Amazon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Amazon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Amazon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amd-backend-engineer.json
+++ b/data/generated/modules/company-role-amd-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "AMD operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. AMD values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but AMD is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "AMD is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "AMD tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but AMD is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but AMD uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amd-data-engineer.json
+++ b/data/generated/modules/company-role-amd-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "AMD operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. AMD values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but AMD is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "AMD is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "AMD tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but AMD is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but AMD uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amd-data-scientist.json
+++ b/data/generated/modules/company-role-amd-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "AMD operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. AMD values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but AMD is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "AMD is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "AMD tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but AMD is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but AMD uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amd-engineering-manager.json
+++ b/data/generated/modules/company-role-amd-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "AMD operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. AMD values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but AMD is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "AMD is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "AMD tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but AMD is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but AMD uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amd-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-amd-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "AMD operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. AMD values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but AMD is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "AMD is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "AMD tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but AMD is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but AMD uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amd-product-manager.json
+++ b/data/generated/modules/company-role-amd-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "AMD operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. AMD values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but AMD isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without show..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tell ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "AMD tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but AMD is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but AMD uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amd-qa-engineer.json
+++ b/data/generated/modules/company-role-amd-qa-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "AMD operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. AMD values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but AMD is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "AMD is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "AMD tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but AMD is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but AMD uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-amd-software-engineer.json
+++ b/data/generated/modules/company-role-amd-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "AMD operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. AMD values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. AMD is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? T..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but AMD uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions or..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "AMD tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but AMD is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but AMD uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "AMD is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-apple-backend-engineer.json
+++ b/data/generated/modules/company-role-apple-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Apple operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Apple values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Apple is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Apple is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Apple tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Apple is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Apple uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-apple-data-scientist.json
+++ b/data/generated/modules/company-role-apple-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Apple operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Apple values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Apple is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Apple is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Apple tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Apple is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Apple uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-apple-engineering-manager.json
+++ b/data/generated/modules/company-role-apple-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Apple operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Apple values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Apple is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Apple is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Apple tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Apple is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Apple uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-apple-frontend-engineer.json
+++ b/data/generated/modules/company-role-apple-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Apple operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Apple values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Apple is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Apple is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Apple tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Apple is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Apple uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-apple-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-apple-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Apple operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Apple values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Apple is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Apple is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Apple tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Apple is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Apple uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-apple-mobile-engineer.json
+++ b/data/generated/modules/company-role-apple-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Apple operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Apple values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Apple is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Apple is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Apple tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Apple is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Apple uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-apple-product-designer.json
+++ b/data/generated/modules/company-role-apple-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Apple operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Apple values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Apple is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Apple is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Apple tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Apple is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Apple uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-apple-product-manager.json
+++ b/data/generated/modules/company-role-apple-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Apple operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Apple values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Apple isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sh..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tel..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Apple tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Apple is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Apple uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-apple-qa-engineer.json
+++ b/data/generated/modules/company-role-apple-qa-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Apple operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Apple values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Apple is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Apple is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Apple tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Apple is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Apple uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-apple-security-engineer.json
+++ b/data/generated/modules/company-role-apple-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Apple operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Apple values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Apple is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Apple is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Apple tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Apple is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Apple uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-apple-software-engineer.json
+++ b/data/generated/modules/company-role-apple-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Apple operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Apple values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Apple is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates?..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Apple uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Apple tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Apple is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Apple uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-apple-technical-program-manager.json
+++ b/data/generated/modules/company-role-apple-technical-program-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Apple operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Apple values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Apple is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Apple is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Apple tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Apple is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Apple uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-apple-ux-researcher.json
+++ b/data/generated/modules/company-role-apple-ux-researcher.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Apple operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Apple values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Apple is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Apple is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Apple tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Apple is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Apple uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Apple is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-asana-backend-engineer.json
+++ b/data/generated/modules/company-role-asana-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Asana operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Asana values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Asana is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Asana is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Asana tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Asana is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Asana values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Asana uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Asana is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-asana-engineering-manager.json
+++ b/data/generated/modules/company-role-asana-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Asana operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Asana values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Asana is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Asana is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Asana tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Asana is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Asana values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Asana uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Asana is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-asana-frontend-engineer.json
+++ b/data/generated/modules/company-role-asana-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Asana operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Asana values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Asana is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Asana is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Asana tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Asana is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Asana values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Asana uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Asana is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-asana-product-designer.json
+++ b/data/generated/modules/company-role-asana-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Asana operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Asana values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Asana is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Asana is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Asana tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Asana is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Asana values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Asana uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Asana is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-asana-product-manager.json
+++ b/data/generated/modules/company-role-asana-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Asana operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Asana values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Asana isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sh..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Asana is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tel..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Asana tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Asana is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Asana values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Asana uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Asana is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-asana-software-engineer.json
+++ b/data/generated/modules/company-role-asana-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Asana operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Asana values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Asana is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates?..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Asana uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Asana tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Asana is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Asana values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Asana uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Asana is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-atlassian-backend-engineer.json
+++ b/data/generated/modules/company-role-atlassian-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Atlassian operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Atlassian values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Atlassian is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Atlassian is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Atlassian tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Atlassian is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Atlassian uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-atlassian-data-scientist.json
+++ b/data/generated/modules/company-role-atlassian-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Atlassian operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Atlassian values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Atlassian is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Atlassian is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Atlassian tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Atlassian is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Atlassian uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-atlassian-engineering-manager.json
+++ b/data/generated/modules/company-role-atlassian-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Atlassian operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Atlassian values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Atlassian is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Atlassian is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Atlassian tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Atlassian is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Atlassian uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-atlassian-frontend-engineer.json
+++ b/data/generated/modules/company-role-atlassian-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Atlassian operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Atlassian values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Atlassian is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Atlassian is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Atlassian tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Atlassian is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Atlassian uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-atlassian-product-designer.json
+++ b/data/generated/modules/company-role-atlassian-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Atlassian operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Atlassian values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Atlassian is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Atlassian is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Atlassian tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Atlassian is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Atlassian uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-atlassian-product-manager.json
+++ b/data/generated/modules/company-role-atlassian-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Atlassian operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Atlassian values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Atlassian isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing withou..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Atlassian tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Atlassian is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Atlassian uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-atlassian-software-engineer.json
+++ b/data/generated/modules/company-role-atlassian-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Atlassian operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Atlassian values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Atlassian is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upda..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Atlassian uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questi..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Atlassian tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Atlassian is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Atlassian uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-atlassian-ux-researcher.json
+++ b/data/generated/modules/company-role-atlassian-ux-researcher.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Atlassian operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Atlassian values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Atlassian is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Atlassian is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Atlassian tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Atlassian is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Atlassian uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Atlassian is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bain-business-analyst.json
+++ b/data/generated/modules/company-role-bain-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Bain & Company operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Bain & Company values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Bain & Company is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Bain & Company is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Bain & Company tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Bain & Company is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bain & Company values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Bain & Company uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bain & Company is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bain-data-scientist.json
+++ b/data/generated/modules/company-role-bain-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Bain & Company operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Bain & Company values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Bain & Company is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Bain & Company is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Bain & Company tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Bain & Company is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bain & Company values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Bain & Company uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bain & Company is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bain-management-consultant.json
+++ b/data/generated/modules/company-role-bain-management-consultant.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Bain & Company operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Bain & Company values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Bain & Company is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Bain & Company is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Bain & Company tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Bain & Company is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bain & Company values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Bain & Company uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bain & Company is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bain-product-manager.json
+++ b/data/generated/modules/company-role-bain-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Bain & Company operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Bain & Company values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Bain & Company isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing w..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bain & Company is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Bain & Company tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Bain & Company is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bain & Company values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Bain & Company uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bain & Company is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bank-of-america-backend-engineer.json
+++ b/data/generated/modules/company-role-bank-of-america-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Bank of America operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Bank of America values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Bank of America is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Bank of America is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Bank of America tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Bank of America is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Bank of America uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bank-of-america-business-analyst.json
+++ b/data/generated/modules/company-role-bank-of-america-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Bank of America operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Bank of America values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Bank of America is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Bank of America is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Bank of America tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Bank of America is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Bank of America uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bank-of-america-data-engineer.json
+++ b/data/generated/modules/company-role-bank-of-america-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Bank of America operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Bank of America values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Bank of America is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Bank of America is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Bank of America tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Bank of America is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Bank of America uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bank-of-america-data-scientist.json
+++ b/data/generated/modules/company-role-bank-of-america-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Bank of America operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Bank of America values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Bank of America is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Bank of America is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Bank of America tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Bank of America is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Bank of America uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bank-of-america-engineering-manager.json
+++ b/data/generated/modules/company-role-bank-of-america-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Bank of America operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Bank of America values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Bank of America is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Bank of America is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Bank of America tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Bank of America is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Bank of America uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bank-of-america-financial-analyst.json
+++ b/data/generated/modules/company-role-bank-of-america-financial-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Bank of America operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Bank of America values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Bank of America is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Bank of America is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Bank of America tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Bank of America is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Bank of America uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bank-of-america-product-manager.json
+++ b/data/generated/modules/company-role-bank-of-america-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Bank of America operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Bank of America values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Bank of America isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either '..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Bank of America tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Bank of America is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Bank of America uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bank-of-america-software-engineer.json
+++ b/data/generated/modules/company-role-bank-of-america-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Bank of America operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Bank of America values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Bank of America is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and ke..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Bank of America uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Bank of America tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Bank of America is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Bank of America uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Bank of America is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bcg-business-analyst.json
+++ b/data/generated/modules/company-role-bcg-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Boston Consulting Group operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The m..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Boston Consulting Group values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the beh..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Boston Consulting Group is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge whe..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Boston Consulting Group is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is ite..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Boston Consulting Group tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to se..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Boston Consulting Group is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's bet..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Boston Consulting Group values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Boston Consulting Group uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Boston Consulting Group is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify t..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bcg-data-scientist.json
+++ b/data/generated/modules/company-role-bcg-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Boston Consulting Group operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The m..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Boston Consulting Group values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the beh..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Boston Consulting Group is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge whe..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Boston Consulting Group is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is ite..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Boston Consulting Group tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to se..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Boston Consulting Group is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's bet..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Boston Consulting Group values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Boston Consulting Group uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Boston Consulting Group is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify t..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bcg-management-consultant.json
+++ b/data/generated/modules/company-role-bcg-management-consultant.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Boston Consulting Group operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The m..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Boston Consulting Group values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the beh..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Boston Consulting Group is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge whe..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Boston Consulting Group is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is ite..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Boston Consulting Group tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to se..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Boston Consulting Group is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's bet..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Boston Consulting Group values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Boston Consulting Group uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Boston Consulting Group is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify t..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bcg-product-manager.json
+++ b/data/generated/modules/company-role-bcg-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Boston Consulting Group operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The m..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Boston Consulting Group values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the beh..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Boston Consulting Group isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random g..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Boston Consulting Group is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Boston Consulting Group tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to se..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Boston Consulting Group is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's bet..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Boston Consulting Group values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Boston Consulting Group uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Boston Consulting Group is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify t..."
           }
         }
       ]

--- a/data/generated/modules/company-role-bcg-software-engineer.json
+++ b/data/generated/modules/company-role-bcg-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Boston Consulting Group operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The m..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Boston Consulting Group values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the beh..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Boston Consulting Group is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limit..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Boston Consulting Group uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask cla..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Boston Consulting Group tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to se..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Boston Consulting Group is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's bet..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Boston Consulting Group values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Boston Consulting Group uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Boston Consulting Group is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify t..."
           }
         }
       ]

--- a/data/generated/modules/company-role-best-buy-backend-engineer.json
+++ b/data/generated/modules/company-role-best-buy-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Best Buy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Best Buy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Best Buy is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Best Buy is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Best Buy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Best Buy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Best Buy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Best Buy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Best Buy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-best-buy-data-engineer.json
+++ b/data/generated/modules/company-role-best-buy-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Best Buy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Best Buy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Best Buy is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Best Buy is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Best Buy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Best Buy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Best Buy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Best Buy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Best Buy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-best-buy-data-scientist.json
+++ b/data/generated/modules/company-role-best-buy-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Best Buy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Best Buy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Best Buy is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Best Buy is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Best Buy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Best Buy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Best Buy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Best Buy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Best Buy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-best-buy-engineering-manager.json
+++ b/data/generated/modules/company-role-best-buy-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Best Buy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Best Buy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Best Buy is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Best Buy is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Best Buy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Best Buy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Best Buy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Best Buy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Best Buy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-best-buy-product-manager.json
+++ b/data/generated/modules/company-role-best-buy-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Best Buy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Best Buy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Best Buy isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Best Buy is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Best Buy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Best Buy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Best Buy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Best Buy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Best Buy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-best-buy-software-engineer.json
+++ b/data/generated/modules/company-role-best-buy-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Best Buy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Best Buy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Best Buy is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updat..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Best Buy uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questio..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Best Buy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Best Buy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Best Buy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Best Buy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Best Buy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-blackrock-backend-engineer.json
+++ b/data/generated/modules/company-role-blackrock-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "BlackRock operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. BlackRock values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but BlackRock is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "BlackRock is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "BlackRock tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but BlackRock is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but BlackRock uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-blackrock-business-analyst.json
+++ b/data/generated/modules/company-role-blackrock-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "BlackRock operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. BlackRock values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but BlackRock is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "BlackRock is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "BlackRock tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but BlackRock is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but BlackRock uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-blackrock-data-engineer.json
+++ b/data/generated/modules/company-role-blackrock-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "BlackRock operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. BlackRock values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but BlackRock is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "BlackRock is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "BlackRock tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but BlackRock is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but BlackRock uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-blackrock-data-scientist.json
+++ b/data/generated/modules/company-role-blackrock-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "BlackRock operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. BlackRock values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but BlackRock is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "BlackRock is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "BlackRock tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but BlackRock is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but BlackRock uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-blackrock-engineering-manager.json
+++ b/data/generated/modules/company-role-blackrock-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "BlackRock operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. BlackRock values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but BlackRock is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "BlackRock is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "BlackRock tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but BlackRock is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but BlackRock uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-blackrock-financial-analyst.json
+++ b/data/generated/modules/company-role-blackrock-financial-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "BlackRock operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. BlackRock values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but BlackRock is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "BlackRock is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "BlackRock tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but BlackRock is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but BlackRock uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-blackrock-product-manager.json
+++ b/data/generated/modules/company-role-blackrock-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "BlackRock operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. BlackRock values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but BlackRock isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing withou..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "BlackRock tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but BlackRock is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but BlackRock uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-blackrock-software-engineer.json
+++ b/data/generated/modules/company-role-blackrock-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "BlackRock operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. BlackRock values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. BlackRock is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upda..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but BlackRock uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questi..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "BlackRock tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but BlackRock is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but BlackRock uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "BlackRock is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-block-backend-engineer.json
+++ b/data/generated/modules/company-role-block-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Block operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Block values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Block is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Block is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Block tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Block is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Block uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-block-data-engineer.json
+++ b/data/generated/modules/company-role-block-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Block operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Block values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Block is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Block is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Block tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Block is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Block uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-block-data-scientist.json
+++ b/data/generated/modules/company-role-block-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Block operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Block values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Block is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Block is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Block tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Block is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Block uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-block-engineering-manager.json
+++ b/data/generated/modules/company-role-block-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Block operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Block values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Block is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Block is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Block tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Block is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Block uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-block-mobile-engineer.json
+++ b/data/generated/modules/company-role-block-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Block operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Block values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Block is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Block is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Block tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Block is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Block uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-block-product-designer.json
+++ b/data/generated/modules/company-role-block-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Block operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Block values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Block is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Block is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Block tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Block is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Block uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-block-product-manager.json
+++ b/data/generated/modules/company-role-block-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Block operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Block values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Block isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sh..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tel..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Block tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Block is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Block uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-block-security-engineer.json
+++ b/data/generated/modules/company-role-block-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Block operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Block values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Block is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Block is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Block tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Block is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Block uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-block-software-engineer.json
+++ b/data/generated/modules/company-role-block-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Block operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Block values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Block is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates?..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Block uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Block tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Block is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Block uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Block is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-booz-allen-business-analyst.json
+++ b/data/generated/modules/company-role-booz-allen-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Booz Allen Hamilton operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Booz Allen Hamilton values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavio..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Booz Allen Hamilton is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Booz Allen Hamilton is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterati..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Booz Allen Hamilton tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Booz Allen Hamilton is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Booz Allen Hamilton values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or r..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Booz Allen Hamilton uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd w..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Booz Allen Hamilton is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the r..."
           }
         }
       ]

--- a/data/generated/modules/company-role-booz-allen-data-scientist.json
+++ b/data/generated/modules/company-role-booz-allen-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Booz Allen Hamilton operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Booz Allen Hamilton values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavio..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Booz Allen Hamilton is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Booz Allen Hamilton is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterati..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Booz Allen Hamilton tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Booz Allen Hamilton is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Booz Allen Hamilton values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or r..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Booz Allen Hamilton uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd w..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Booz Allen Hamilton is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the r..."
           }
         }
       ]

--- a/data/generated/modules/company-role-booz-allen-management-consultant.json
+++ b/data/generated/modules/company-role-booz-allen-management-consultant.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Booz Allen Hamilton operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Booz Allen Hamilton values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavio..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Booz Allen Hamilton is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Booz Allen Hamilton is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterati..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Booz Allen Hamilton tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Booz Allen Hamilton is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Booz Allen Hamilton values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or r..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Booz Allen Hamilton uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd w..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Booz Allen Hamilton is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the r..."
           }
         }
       ]

--- a/data/generated/modules/company-role-booz-allen-security-engineer.json
+++ b/data/generated/modules/company-role-booz-allen-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Booz Allen Hamilton operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Booz Allen Hamilton values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavio..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Booz Allen Hamilton is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Booz Allen Hamilton is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterati..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Booz Allen Hamilton tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Booz Allen Hamilton is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Booz Allen Hamilton values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or r..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Booz Allen Hamilton uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd w..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Booz Allen Hamilton is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the r..."
           }
         }
       ]

--- a/data/generated/modules/company-role-booz-allen-software-engineer.json
+++ b/data/generated/modules/company-role-booz-allen-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Booz Allen Hamilton operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Booz Allen Hamilton values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavio..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Booz Allen Hamilton is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits an..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Booz Allen Hamilton uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarify..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Booz Allen Hamilton tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Booz Allen Hamilton is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Booz Allen Hamilton values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or r..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Booz Allen Hamilton uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd w..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Booz Allen Hamilton is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the r..."
           }
         }
       ]

--- a/data/generated/modules/company-role-capgemini-business-analyst.json
+++ b/data/generated/modules/company-role-capgemini-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Capgemini operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Capgemini values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Capgemini is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Capgemini is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Capgemini tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Capgemini is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Capgemini values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Capgemini uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Capgemini is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-capgemini-data-scientist.json
+++ b/data/generated/modules/company-role-capgemini-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Capgemini operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Capgemini values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Capgemini is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Capgemini is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Capgemini tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Capgemini is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Capgemini values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Capgemini uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Capgemini is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-capgemini-management-consultant.json
+++ b/data/generated/modules/company-role-capgemini-management-consultant.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Capgemini operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Capgemini values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Capgemini is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Capgemini is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Capgemini tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Capgemini is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Capgemini values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Capgemini uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Capgemini is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-capgemini-software-engineer.json
+++ b/data/generated/modules/company-role-capgemini-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Capgemini operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Capgemini values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Capgemini is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upda..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Capgemini uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questi..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Capgemini tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Capgemini is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Capgemini values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Capgemini uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Capgemini is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cerner-engineering-manager.json
+++ b/data/generated/modules/company-role-cerner-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cerner operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cerner values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Cerner is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Cerner is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cerner tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cerner is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cerner values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cerner uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cerner is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cerner-product-manager.json
+++ b/data/generated/modules/company-role-cerner-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cerner operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cerner values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Cerner isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cerner is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cerner tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cerner is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cerner values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cerner uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cerner is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cerner-qa-engineer.json
+++ b/data/generated/modules/company-role-cerner-qa-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cerner operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cerner values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Cerner is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Cerner is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cerner tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cerner is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cerner values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cerner uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cerner is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cerner-software-engineer.json
+++ b/data/generated/modules/company-role-cerner-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cerner operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cerner values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Cerner is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Cerner uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cerner tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cerner is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cerner values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cerner uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cerner is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cerner-technical-program-manager.json
+++ b/data/generated/modules/company-role-cerner-technical-program-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cerner operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cerner values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Cerner is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Cerner is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cerner tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cerner is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cerner values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cerner uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cerner is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-charles-schwab-backend-engineer.json
+++ b/data/generated/modules/company-role-charles-schwab-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Charles Schwab operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Charles Schwab values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Charles Schwab is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Charles Schwab is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Charles Schwab tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Charles Schwab is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Charles Schwab values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Charles Schwab uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Charles Schwab is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-charles-schwab-business-analyst.json
+++ b/data/generated/modules/company-role-charles-schwab-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Charles Schwab operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Charles Schwab values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Charles Schwab is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Charles Schwab is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Charles Schwab tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Charles Schwab is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Charles Schwab values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Charles Schwab uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Charles Schwab is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-charles-schwab-data-engineer.json
+++ b/data/generated/modules/company-role-charles-schwab-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Charles Schwab operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Charles Schwab values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Charles Schwab is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Charles Schwab is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Charles Schwab tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Charles Schwab is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Charles Schwab values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Charles Schwab uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Charles Schwab is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-charles-schwab-data-scientist.json
+++ b/data/generated/modules/company-role-charles-schwab-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Charles Schwab operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Charles Schwab values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Charles Schwab is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Charles Schwab is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Charles Schwab tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Charles Schwab is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Charles Schwab values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Charles Schwab uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Charles Schwab is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-charles-schwab-financial-analyst.json
+++ b/data/generated/modules/company-role-charles-schwab-financial-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Charles Schwab operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Charles Schwab values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Charles Schwab is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Charles Schwab is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Charles Schwab tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Charles Schwab is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Charles Schwab values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Charles Schwab uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Charles Schwab is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-charles-schwab-product-manager.json
+++ b/data/generated/modules/company-role-charles-schwab-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Charles Schwab operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Charles Schwab values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Charles Schwab isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing w..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Charles Schwab is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Charles Schwab tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Charles Schwab is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Charles Schwab values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Charles Schwab uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Charles Schwab is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-charles-schwab-software-engineer.json
+++ b/data/generated/modules/company-role-charles-schwab-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Charles Schwab operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Charles Schwab values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Charles Schwab is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Charles Schwab uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying q..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Charles Schwab tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Charles Schwab is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Charles Schwab values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Charles Schwab uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Charles Schwab is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-chewy-backend-engineer.json
+++ b/data/generated/modules/company-role-chewy-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Chewy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Chewy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Chewy is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Chewy is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Chewy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Chewy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Chewy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Chewy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Chewy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-chewy-data-engineer.json
+++ b/data/generated/modules/company-role-chewy-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Chewy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Chewy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Chewy is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Chewy is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Chewy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Chewy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Chewy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Chewy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Chewy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-chewy-data-scientist.json
+++ b/data/generated/modules/company-role-chewy-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Chewy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Chewy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Chewy is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Chewy is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Chewy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Chewy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Chewy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Chewy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Chewy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-chewy-engineering-manager.json
+++ b/data/generated/modules/company-role-chewy-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Chewy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Chewy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Chewy is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Chewy is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Chewy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Chewy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Chewy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Chewy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Chewy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-chewy-product-designer.json
+++ b/data/generated/modules/company-role-chewy-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Chewy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Chewy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Chewy is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Chewy is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Chewy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Chewy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Chewy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Chewy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Chewy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-chewy-product-manager.json
+++ b/data/generated/modules/company-role-chewy-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Chewy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Chewy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Chewy isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sh..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Chewy is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tel..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Chewy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Chewy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Chewy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Chewy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Chewy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-chewy-software-engineer.json
+++ b/data/generated/modules/company-role-chewy-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Chewy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Chewy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Chewy is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates?..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Chewy uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Chewy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Chewy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Chewy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Chewy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Chewy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cisco-backend-engineer.json
+++ b/data/generated/modules/company-role-cisco-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cisco operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cisco values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Cisco is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Cisco is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cisco tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cisco is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cisco uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cisco-devops-engineer.json
+++ b/data/generated/modules/company-role-cisco-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cisco operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cisco values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Cisco is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Cisco is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cisco tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cisco is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cisco uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cisco-engineering-manager.json
+++ b/data/generated/modules/company-role-cisco-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cisco operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cisco values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Cisco is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Cisco is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cisco tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cisco is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cisco uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cisco-product-manager.json
+++ b/data/generated/modules/company-role-cisco-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cisco operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cisco values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Cisco isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sh..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tel..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cisco tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cisco is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cisco uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cisco-sales-engineer.json
+++ b/data/generated/modules/company-role-cisco-sales-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cisco operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cisco values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Cisco is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Cisco is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cisco tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cisco is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cisco uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cisco-security-engineer.json
+++ b/data/generated/modules/company-role-cisco-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cisco operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cisco values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Cisco is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Cisco is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cisco tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cisco is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cisco uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cisco-software-engineer.json
+++ b/data/generated/modules/company-role-cisco-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cisco operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cisco values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Cisco is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates?..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Cisco uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cisco tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cisco is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cisco uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cisco-solutions-architect.json
+++ b/data/generated/modules/company-role-cisco-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cisco operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cisco values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Cisco is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Cisco is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cisco tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cisco is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cisco uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cisco is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-citadel-backend-engineer.json
+++ b/data/generated/modules/company-role-citadel-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Citadel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Citadel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Citadel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Citadel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Citadel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Citadel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Citadel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Citadel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Citadel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-citadel-data-engineer.json
+++ b/data/generated/modules/company-role-citadel-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Citadel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Citadel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Citadel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Citadel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Citadel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Citadel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Citadel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Citadel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Citadel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-citadel-data-scientist.json
+++ b/data/generated/modules/company-role-citadel-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Citadel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Citadel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Citadel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Citadel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Citadel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Citadel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Citadel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Citadel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Citadel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-citadel-financial-analyst.json
+++ b/data/generated/modules/company-role-citadel-financial-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Citadel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Citadel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Citadel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Citadel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Citadel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Citadel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Citadel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Citadel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Citadel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-citadel-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-citadel-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Citadel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Citadel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Citadel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Citadel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Citadel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Citadel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Citadel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Citadel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Citadel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-citadel-software-engineer.json
+++ b/data/generated/modules/company-role-citadel-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Citadel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Citadel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Citadel is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key update..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Citadel uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying question..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Citadel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Citadel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Citadel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Citadel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Citadel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cloudflare-backend-engineer.json
+++ b/data/generated/modules/company-role-cloudflare-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cloudflare operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cloudflare values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Cloudflare is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Cloudflare is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cloudflare tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cloudflare is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cloudflare values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cloudflare uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cloudflare is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cloudflare-devops-engineer.json
+++ b/data/generated/modules/company-role-cloudflare-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cloudflare operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cloudflare values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Cloudflare is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Cloudflare is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cloudflare tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cloudflare is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cloudflare values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cloudflare uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cloudflare is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cloudflare-engineering-manager.json
+++ b/data/generated/modules/company-role-cloudflare-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cloudflare operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cloudflare values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Cloudflare is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Cloudflare is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cloudflare tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cloudflare is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cloudflare values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cloudflare uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cloudflare is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cloudflare-product-manager.json
+++ b/data/generated/modules/company-role-cloudflare-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cloudflare operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cloudflare values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Cloudflare isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing witho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cloudflare is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I jus..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cloudflare tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cloudflare is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cloudflare values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cloudflare uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cloudflare is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cloudflare-security-engineer.json
+++ b/data/generated/modules/company-role-cloudflare-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cloudflare operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cloudflare values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Cloudflare is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Cloudflare is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cloudflare tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cloudflare is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cloudflare values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cloudflare uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cloudflare is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cloudflare-software-engineer.json
+++ b/data/generated/modules/company-role-cloudflare-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cloudflare operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cloudflare values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Cloudflare is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Cloudflare uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying quest..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cloudflare tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cloudflare is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cloudflare values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cloudflare uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cloudflare is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cloudflare-solutions-architect.json
+++ b/data/generated/modules/company-role-cloudflare-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Cloudflare operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Cloudflare values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Cloudflare is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Cloudflare is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Cloudflare tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Cloudflare is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cloudflare values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Cloudflare uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Cloudflare is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-coinbase-backend-engineer.json
+++ b/data/generated/modules/company-role-coinbase-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Coinbase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Coinbase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Coinbase is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Coinbase is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Coinbase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Coinbase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Coinbase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-coinbase-data-scientist.json
+++ b/data/generated/modules/company-role-coinbase-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Coinbase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Coinbase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Coinbase is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Coinbase is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Coinbase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Coinbase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Coinbase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-coinbase-devops-engineer.json
+++ b/data/generated/modules/company-role-coinbase-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Coinbase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Coinbase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Coinbase is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Coinbase is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Coinbase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Coinbase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Coinbase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-coinbase-engineering-manager.json
+++ b/data/generated/modules/company-role-coinbase-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Coinbase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Coinbase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Coinbase is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Coinbase is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Coinbase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Coinbase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Coinbase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-coinbase-product-designer.json
+++ b/data/generated/modules/company-role-coinbase-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Coinbase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Coinbase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Coinbase is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Coinbase is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Coinbase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Coinbase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Coinbase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-coinbase-product-manager.json
+++ b/data/generated/modules/company-role-coinbase-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Coinbase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Coinbase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Coinbase isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Coinbase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Coinbase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Coinbase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-coinbase-security-engineer.json
+++ b/data/generated/modules/company-role-coinbase-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Coinbase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Coinbase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Coinbase is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Coinbase is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Coinbase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Coinbase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Coinbase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-coinbase-software-engineer.json
+++ b/data/generated/modules/company-role-coinbase-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Coinbase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Coinbase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Coinbase is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updat..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Coinbase uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questio..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Coinbase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Coinbase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Coinbase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Coinbase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-costco-backend-engineer.json
+++ b/data/generated/modules/company-role-costco-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Costco operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Costco values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Costco is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Costco is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Costco tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Costco is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Costco values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Costco uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Costco is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-costco-business-analyst.json
+++ b/data/generated/modules/company-role-costco-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Costco operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Costco values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Costco is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Costco is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Costco tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Costco is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Costco values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Costco uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Costco is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-costco-data-engineer.json
+++ b/data/generated/modules/company-role-costco-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Costco operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Costco values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Costco is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Costco is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Costco tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Costco is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Costco values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Costco uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Costco is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-costco-data-scientist.json
+++ b/data/generated/modules/company-role-costco-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Costco operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Costco values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Costco is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Costco is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Costco tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Costco is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Costco values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Costco uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Costco is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-costco-engineering-manager.json
+++ b/data/generated/modules/company-role-costco-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Costco operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Costco values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Costco is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Costco is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Costco tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Costco is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Costco values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Costco uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Costco is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-costco-product-manager.json
+++ b/data/generated/modules/company-role-costco-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Costco operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Costco values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Costco isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Costco is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Costco tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Costco is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Costco values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Costco uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Costco is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-costco-software-engineer.json
+++ b/data/generated/modules/company-role-costco-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Costco operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Costco values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Costco is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Costco uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Costco tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Costco is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Costco values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Costco uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Costco is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cvs-health-backend-engineer.json
+++ b/data/generated/modules/company-role-cvs-health-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "CVS Health operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. CVS Health values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but CVS Health is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "CVS Health is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "CVS Health tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but CVS Health is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "CVS Health values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but CVS Health uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "CVS Health is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cvs-health-business-analyst.json
+++ b/data/generated/modules/company-role-cvs-health-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "CVS Health operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. CVS Health values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but CVS Health is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "CVS Health is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "CVS Health tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but CVS Health is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "CVS Health values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but CVS Health uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "CVS Health is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cvs-health-data-engineer.json
+++ b/data/generated/modules/company-role-cvs-health-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "CVS Health operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. CVS Health values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but CVS Health is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "CVS Health is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "CVS Health tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but CVS Health is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "CVS Health values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but CVS Health uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "CVS Health is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cvs-health-data-scientist.json
+++ b/data/generated/modules/company-role-cvs-health-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "CVS Health operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. CVS Health values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but CVS Health is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "CVS Health is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "CVS Health tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but CVS Health is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "CVS Health values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but CVS Health uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "CVS Health is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cvs-health-engineering-manager.json
+++ b/data/generated/modules/company-role-cvs-health-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "CVS Health operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. CVS Health values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but CVS Health is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "CVS Health is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "CVS Health tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but CVS Health is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "CVS Health values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but CVS Health uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "CVS Health is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cvs-health-product-manager.json
+++ b/data/generated/modules/company-role-cvs-health-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "CVS Health operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. CVS Health values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but CVS Health isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing witho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "CVS Health is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I jus..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "CVS Health tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but CVS Health is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "CVS Health values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but CVS Health uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "CVS Health is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-cvs-health-software-engineer.json
+++ b/data/generated/modules/company-role-cvs-health-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "CVS Health operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. CVS Health values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. CVS Health is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but CVS Health uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying quest..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "CVS Health tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but CVS Health is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "CVS Health values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but CVS Health uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "CVS Health is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-databricks-backend-engineer.json
+++ b/data/generated/modules/company-role-databricks-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Databricks operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Databricks values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Databricks is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Databricks is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Databricks tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Databricks is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Databricks uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-databricks-data-engineer.json
+++ b/data/generated/modules/company-role-databricks-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Databricks operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Databricks values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Databricks is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Databricks is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Databricks tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Databricks is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Databricks uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-databricks-data-scientist.json
+++ b/data/generated/modules/company-role-databricks-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Databricks operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Databricks values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Databricks is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Databricks is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Databricks tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Databricks is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Databricks uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-databricks-devops-engineer.json
+++ b/data/generated/modules/company-role-databricks-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Databricks operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Databricks values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Databricks is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Databricks is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Databricks tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Databricks is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Databricks uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-databricks-engineering-manager.json
+++ b/data/generated/modules/company-role-databricks-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Databricks operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Databricks values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Databricks is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Databricks is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Databricks tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Databricks is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Databricks uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-databricks-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-databricks-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Databricks operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Databricks values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Databricks is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Databricks is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Databricks tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Databricks is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Databricks uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-databricks-product-manager.json
+++ b/data/generated/modules/company-role-databricks-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Databricks operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Databricks values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Databricks isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing witho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I jus..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Databricks tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Databricks is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Databricks uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-databricks-software-engineer.json
+++ b/data/generated/modules/company-role-databricks-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Databricks operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Databricks values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Databricks is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Databricks uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying quest..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Databricks tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Databricks is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Databricks uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-databricks-solutions-architect.json
+++ b/data/generated/modules/company-role-databricks-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Databricks operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Databricks values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Databricks is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Databricks is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Databricks tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Databricks is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Databricks uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Databricks is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-deloitte-business-analyst.json
+++ b/data/generated/modules/company-role-deloitte-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Deloitte operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Deloitte values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Deloitte is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Deloitte is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Deloitte tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Deloitte is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Deloitte values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Deloitte uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Deloitte is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-deloitte-data-scientist.json
+++ b/data/generated/modules/company-role-deloitte-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Deloitte operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Deloitte values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Deloitte is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Deloitte is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Deloitte tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Deloitte is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Deloitte values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Deloitte uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Deloitte is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-deloitte-financial-analyst.json
+++ b/data/generated/modules/company-role-deloitte-financial-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Deloitte operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Deloitte values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Deloitte is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Deloitte is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Deloitte tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Deloitte is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Deloitte values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Deloitte uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Deloitte is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-deloitte-management-consultant.json
+++ b/data/generated/modules/company-role-deloitte-management-consultant.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Deloitte operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Deloitte values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Deloitte is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Deloitte is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Deloitte tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Deloitte is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Deloitte values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Deloitte uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Deloitte is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-deloitte-software-engineer.json
+++ b/data/generated/modules/company-role-deloitte-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Deloitte operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Deloitte values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Deloitte is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updat..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Deloitte uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questio..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Deloitte tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Deloitte is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Deloitte values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Deloitte uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Deloitte is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-disney-backend-engineer.json
+++ b/data/generated/modules/company-role-disney-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Disney operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Disney values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Disney is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Disney is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Disney tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Disney is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Disney uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-disney-data-engineer.json
+++ b/data/generated/modules/company-role-disney-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Disney operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Disney values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Disney is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Disney is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Disney tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Disney is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Disney uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-disney-data-scientist.json
+++ b/data/generated/modules/company-role-disney-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Disney operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Disney values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Disney is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Disney is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Disney tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Disney is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Disney uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-disney-engineering-manager.json
+++ b/data/generated/modules/company-role-disney-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Disney operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Disney values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Disney is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Disney is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Disney tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Disney is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Disney uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-disney-frontend-engineer.json
+++ b/data/generated/modules/company-role-disney-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Disney operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Disney values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Disney is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Disney is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Disney tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Disney is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Disney uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-disney-mobile-engineer.json
+++ b/data/generated/modules/company-role-disney-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Disney operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Disney values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Disney is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Disney is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Disney tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Disney is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Disney uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-disney-product-designer.json
+++ b/data/generated/modules/company-role-disney-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Disney operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Disney values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Disney is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Disney is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Disney tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Disney is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Disney uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-disney-product-manager.json
+++ b/data/generated/modules/company-role-disney-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Disney operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Disney values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Disney isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Disney tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Disney is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Disney uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-disney-software-engineer.json
+++ b/data/generated/modules/company-role-disney-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Disney operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Disney values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Disney is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Disney uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Disney tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Disney is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Disney uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Disney is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-docusign-backend-engineer.json
+++ b/data/generated/modules/company-role-docusign-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "DocuSign operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. DocuSign values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but DocuSign is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "DocuSign is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "DocuSign tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but DocuSign is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DocuSign values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but DocuSign uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DocuSign is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-docusign-engineering-manager.json
+++ b/data/generated/modules/company-role-docusign-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "DocuSign operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. DocuSign values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but DocuSign is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "DocuSign is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "DocuSign tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but DocuSign is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DocuSign values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but DocuSign uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DocuSign is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-docusign-product-designer.json
+++ b/data/generated/modules/company-role-docusign-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "DocuSign operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. DocuSign values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but DocuSign is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "DocuSign is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "DocuSign tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but DocuSign is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DocuSign values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but DocuSign uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DocuSign is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-docusign-product-manager.json
+++ b/data/generated/modules/company-role-docusign-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "DocuSign operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. DocuSign values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but DocuSign isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DocuSign is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "DocuSign tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but DocuSign is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DocuSign values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but DocuSign uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DocuSign is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-docusign-software-engineer.json
+++ b/data/generated/modules/company-role-docusign-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "DocuSign operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. DocuSign values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. DocuSign is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updat..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but DocuSign uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questio..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "DocuSign tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but DocuSign is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DocuSign values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but DocuSign uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DocuSign is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-doordash-backend-engineer.json
+++ b/data/generated/modules/company-role-doordash-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "DoorDash operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. DoorDash values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but DoorDash is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "DoorDash is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "DoorDash tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but DoorDash is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but DoorDash uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-doordash-data-engineer.json
+++ b/data/generated/modules/company-role-doordash-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "DoorDash operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. DoorDash values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but DoorDash is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "DoorDash is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "DoorDash tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but DoorDash is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but DoorDash uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-doordash-data-scientist.json
+++ b/data/generated/modules/company-role-doordash-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "DoorDash operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. DoorDash values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but DoorDash is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "DoorDash is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "DoorDash tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but DoorDash is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but DoorDash uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-doordash-engineering-manager.json
+++ b/data/generated/modules/company-role-doordash-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "DoorDash operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. DoorDash values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but DoorDash is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "DoorDash is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "DoorDash tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but DoorDash is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but DoorDash uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-doordash-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-doordash-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "DoorDash operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. DoorDash values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but DoorDash is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "DoorDash is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "DoorDash tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but DoorDash is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but DoorDash uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-doordash-mobile-engineer.json
+++ b/data/generated/modules/company-role-doordash-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "DoorDash operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. DoorDash values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but DoorDash is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "DoorDash is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "DoorDash tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but DoorDash is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but DoorDash uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-doordash-product-designer.json
+++ b/data/generated/modules/company-role-doordash-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "DoorDash operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. DoorDash values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but DoorDash is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "DoorDash is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "DoorDash tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but DoorDash is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but DoorDash uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-doordash-product-manager.json
+++ b/data/generated/modules/company-role-doordash-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "DoorDash operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. DoorDash values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but DoorDash isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "DoorDash tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but DoorDash is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but DoorDash uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-doordash-software-engineer.json
+++ b/data/generated/modules/company-role-doordash-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "DoorDash operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. DoorDash values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. DoorDash is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updat..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but DoorDash uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questio..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "DoorDash tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but DoorDash is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but DoorDash uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "DoorDash is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-dropbox-backend-engineer.json
+++ b/data/generated/modules/company-role-dropbox-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Dropbox operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Dropbox values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Dropbox is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Dropbox is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Dropbox tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Dropbox is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Dropbox values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Dropbox uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Dropbox is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-dropbox-data-scientist.json
+++ b/data/generated/modules/company-role-dropbox-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Dropbox operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Dropbox values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Dropbox is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Dropbox is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Dropbox tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Dropbox is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Dropbox values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Dropbox uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Dropbox is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-dropbox-engineering-manager.json
+++ b/data/generated/modules/company-role-dropbox-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Dropbox operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Dropbox values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Dropbox is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Dropbox is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Dropbox tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Dropbox is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Dropbox values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Dropbox uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Dropbox is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-dropbox-frontend-engineer.json
+++ b/data/generated/modules/company-role-dropbox-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Dropbox operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Dropbox values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Dropbox is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Dropbox is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Dropbox tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Dropbox is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Dropbox values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Dropbox uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Dropbox is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-dropbox-product-designer.json
+++ b/data/generated/modules/company-role-dropbox-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Dropbox operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Dropbox values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Dropbox is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Dropbox is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Dropbox tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Dropbox is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Dropbox values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Dropbox uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Dropbox is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-dropbox-product-manager.json
+++ b/data/generated/modules/company-role-dropbox-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Dropbox operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Dropbox values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Dropbox isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Dropbox is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just t..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Dropbox tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Dropbox is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Dropbox values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Dropbox uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Dropbox is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-dropbox-software-engineer.json
+++ b/data/generated/modules/company-role-dropbox-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Dropbox operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Dropbox values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Dropbox is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key update..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Dropbox uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying question..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Dropbox tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Dropbox is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Dropbox values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Dropbox uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Dropbox is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ea-backend-engineer.json
+++ b/data/generated/modules/company-role-ea-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Electronic Arts operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Electronic Arts values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Electronic Arts is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Electronic Arts is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Electronic Arts tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Electronic Arts is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Electronic Arts uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ea-data-scientist.json
+++ b/data/generated/modules/company-role-ea-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Electronic Arts operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Electronic Arts values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Electronic Arts is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Electronic Arts is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Electronic Arts tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Electronic Arts is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Electronic Arts uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ea-engineering-manager.json
+++ b/data/generated/modules/company-role-ea-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Electronic Arts operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Electronic Arts values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Electronic Arts is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Electronic Arts is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Electronic Arts tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Electronic Arts is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Electronic Arts uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ea-frontend-engineer.json
+++ b/data/generated/modules/company-role-ea-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Electronic Arts operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Electronic Arts values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Electronic Arts is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Electronic Arts is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Electronic Arts tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Electronic Arts is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Electronic Arts uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ea-mobile-engineer.json
+++ b/data/generated/modules/company-role-ea-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Electronic Arts operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Electronic Arts values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Electronic Arts is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Electronic Arts is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Electronic Arts tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Electronic Arts is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Electronic Arts uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ea-product-designer.json
+++ b/data/generated/modules/company-role-ea-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Electronic Arts operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Electronic Arts values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Electronic Arts is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Electronic Arts is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Electronic Arts tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Electronic Arts is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Electronic Arts uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ea-product-manager.json
+++ b/data/generated/modules/company-role-ea-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Electronic Arts operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Electronic Arts values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Electronic Arts isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either '..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Electronic Arts tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Electronic Arts is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Electronic Arts uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ea-qa-engineer.json
+++ b/data/generated/modules/company-role-ea-qa-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Electronic Arts operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Electronic Arts values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Electronic Arts is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Electronic Arts is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Electronic Arts tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Electronic Arts is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Electronic Arts uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ea-software-engineer.json
+++ b/data/generated/modules/company-role-ea-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Electronic Arts operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-ques..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Electronic Arts values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? D..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Electronic Arts is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and ke..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Electronic Arts uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Electronic Arts tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Electronic Arts is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to b..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resis..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Electronic Arts uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Electronic Arts is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-elastic-backend-engineer.json
+++ b/data/generated/modules/company-role-elastic-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Elastic operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Elastic values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Elastic is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Elastic is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Elastic tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Elastic is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Elastic values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Elastic uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Elastic is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-elastic-devops-engineer.json
+++ b/data/generated/modules/company-role-elastic-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Elastic operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Elastic values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Elastic is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Elastic is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Elastic tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Elastic is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Elastic values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Elastic uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Elastic is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-elastic-engineering-manager.json
+++ b/data/generated/modules/company-role-elastic-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Elastic operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Elastic values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Elastic is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Elastic is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Elastic tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Elastic is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Elastic values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Elastic uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Elastic is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-elastic-product-manager.json
+++ b/data/generated/modules/company-role-elastic-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Elastic operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Elastic values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Elastic isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Elastic is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just t..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Elastic tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Elastic is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Elastic values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Elastic uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Elastic is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-elastic-software-engineer.json
+++ b/data/generated/modules/company-role-elastic-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Elastic operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Elastic values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Elastic is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key update..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Elastic uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying question..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Elastic tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Elastic is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Elastic values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Elastic uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Elastic is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-elastic-solutions-architect.json
+++ b/data/generated/modules/company-role-elastic-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Elastic operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Elastic values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Elastic is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Elastic is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Elastic tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Elastic is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Elastic values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Elastic uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Elastic is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-epic-engineering-manager.json
+++ b/data/generated/modules/company-role-epic-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Epic Systems operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-questio..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Epic Systems values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do y..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Epic Systems is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd wa..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Epic Systems is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Epic Systems tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cus..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Epic Systems is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be h..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Epic Systems values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Epic Systems uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Epic Systems is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real pro..."
           }
         }
       ]

--- a/data/generated/modules/company-role-epic-product-manager.json
+++ b/data/generated/modules/company-role-epic-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Epic Systems operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-questio..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Epic Systems values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do y..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Epic Systems isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing wit..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Epic Systems is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I j..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Epic Systems tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cus..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Epic Systems is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be h..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Epic Systems values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Epic Systems uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Epic Systems is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real pro..."
           }
         }
       ]

--- a/data/generated/modules/company-role-epic-qa-engineer.json
+++ b/data/generated/modules/company-role-epic-qa-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Epic Systems operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-questio..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Epic Systems values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do y..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Epic Systems is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd wa..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Epic Systems is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Epic Systems tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cus..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Epic Systems is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be h..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Epic Systems values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Epic Systems uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Epic Systems is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real pro..."
           }
         }
       ]

--- a/data/generated/modules/company-role-epic-software-engineer.json
+++ b/data/generated/modules/company-role-epic-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Epic Systems operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-questio..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Epic Systems values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do y..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Epic Systems is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key u..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Epic Systems uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying que..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Epic Systems tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cus..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Epic Systems is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be h..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Epic Systems values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Epic Systems uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Epic Systems is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real pro..."
           }
         }
       ]

--- a/data/generated/modules/company-role-epic-technical-program-manager.json
+++ b/data/generated/modules/company-role-epic-technical-program-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Epic Systems operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-questio..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Epic Systems values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do y..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Epic Systems is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd wa..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Epic Systems is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Epic Systems tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cus..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Epic Systems is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be h..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Epic Systems values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Epic Systems uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Epic Systems is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real pro..."
           }
         }
       ]

--- a/data/generated/modules/company-role-etsy-backend-engineer.json
+++ b/data/generated/modules/company-role-etsy-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Etsy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Etsy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Etsy is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Etsy is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Etsy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Etsy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Etsy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-etsy-data-engineer.json
+++ b/data/generated/modules/company-role-etsy-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Etsy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Etsy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Etsy is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Etsy is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Etsy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Etsy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Etsy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-etsy-data-scientist.json
+++ b/data/generated/modules/company-role-etsy-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Etsy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Etsy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Etsy is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Etsy is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Etsy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Etsy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Etsy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-etsy-engineering-manager.json
+++ b/data/generated/modules/company-role-etsy-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Etsy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Etsy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Etsy is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Etsy is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Etsy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Etsy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Etsy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-etsy-frontend-engineer.json
+++ b/data/generated/modules/company-role-etsy-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Etsy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Etsy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Etsy is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Etsy is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Etsy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Etsy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Etsy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-etsy-product-designer.json
+++ b/data/generated/modules/company-role-etsy-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Etsy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Etsy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Etsy is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Etsy is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Etsy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Etsy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Etsy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-etsy-product-manager.json
+++ b/data/generated/modules/company-role-etsy-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Etsy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Etsy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Etsy isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tell..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Etsy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Etsy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Etsy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-etsy-software-engineer.json
+++ b/data/generated/modules/company-role-etsy-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Etsy operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Etsy values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Etsy is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Etsy uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions o..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Etsy tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Etsy is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Etsy uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Etsy is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ey-business-analyst.json
+++ b/data/generated/modules/company-role-ey-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "EY operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do y..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. EY values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ow..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but EY is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to veri..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "EY is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "EY tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but EY is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abou..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "EY values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Candi..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but EY uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? The..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "EY is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befor..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ey-data-scientist.json
+++ b/data/generated/modules/company-role-ey-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "EY operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do y..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. EY values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ow..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but EY is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to veri..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "EY is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "EY tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but EY is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abou..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "EY values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Candi..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but EY uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? The..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "EY is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befor..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ey-financial-analyst.json
+++ b/data/generated/modules/company-role-ey-financial-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "EY operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do y..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. EY values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ow..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but EY is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to veri..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "EY is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "EY tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but EY is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abou..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "EY values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Candi..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but EY uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? The..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "EY is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befor..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ey-management-consultant.json
+++ b/data/generated/modules/company-role-ey-management-consultant.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "EY operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do y..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. EY values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ow..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but EY is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to veri..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "EY is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "EY tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but EY is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abou..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "EY values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Candi..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but EY uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? The..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "EY is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befor..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ey-software-engineer.json
+++ b/data/generated/modules/company-role-ey-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "EY operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do y..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. EY values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ow..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. EY is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? Th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but EY uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions or ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "EY tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but EY is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abou..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "EY values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Candi..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but EY uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? The..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "EY is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befor..."
           }
         }
       ]

--- a/data/generated/modules/company-role-fidelity-backend-engineer.json
+++ b/data/generated/modules/company-role-fidelity-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Fidelity operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Fidelity values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Fidelity is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Fidelity is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Fidelity tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Fidelity is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Fidelity uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-fidelity-business-analyst.json
+++ b/data/generated/modules/company-role-fidelity-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Fidelity operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Fidelity values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Fidelity is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Fidelity is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Fidelity tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Fidelity is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Fidelity uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-fidelity-data-engineer.json
+++ b/data/generated/modules/company-role-fidelity-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Fidelity operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Fidelity values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Fidelity is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Fidelity is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Fidelity tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Fidelity is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Fidelity uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-fidelity-data-scientist.json
+++ b/data/generated/modules/company-role-fidelity-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Fidelity operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Fidelity values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Fidelity is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Fidelity is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Fidelity tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Fidelity is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Fidelity uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-fidelity-engineering-manager.json
+++ b/data/generated/modules/company-role-fidelity-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Fidelity operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Fidelity values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Fidelity is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Fidelity is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Fidelity tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Fidelity is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Fidelity uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-fidelity-financial-analyst.json
+++ b/data/generated/modules/company-role-fidelity-financial-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Fidelity operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Fidelity values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Fidelity is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Fidelity is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Fidelity tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Fidelity is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Fidelity uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-fidelity-product-manager.json
+++ b/data/generated/modules/company-role-fidelity-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Fidelity operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Fidelity values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Fidelity isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Fidelity tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Fidelity is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Fidelity uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-fidelity-software-engineer.json
+++ b/data/generated/modules/company-role-fidelity-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Fidelity operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Fidelity values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Fidelity is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updat..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Fidelity uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questio..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Fidelity tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Fidelity is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Fidelity uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Fidelity is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-figma-backend-engineer.json
+++ b/data/generated/modules/company-role-figma-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Figma operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Figma values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Figma is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Figma is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Figma tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Figma is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Figma values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Figma uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Figma is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-figma-engineering-manager.json
+++ b/data/generated/modules/company-role-figma-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Figma operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Figma values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Figma is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Figma is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Figma tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Figma is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Figma values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Figma uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Figma is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-figma-frontend-engineer.json
+++ b/data/generated/modules/company-role-figma-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Figma operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Figma values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Figma is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Figma is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Figma tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Figma is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Figma values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Figma uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Figma is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-figma-product-designer.json
+++ b/data/generated/modules/company-role-figma-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Figma operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Figma values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Figma is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Figma is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Figma tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Figma is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Figma values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Figma uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Figma is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-figma-product-manager.json
+++ b/data/generated/modules/company-role-figma-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Figma operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Figma values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Figma isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sh..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Figma is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tel..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Figma tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Figma is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Figma values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Figma uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Figma is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-figma-software-engineer.json
+++ b/data/generated/modules/company-role-figma-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Figma operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Figma values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Figma is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates?..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Figma uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Figma tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Figma is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Figma values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Figma uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Figma is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-figma-ux-researcher.json
+++ b/data/generated/modules/company-role-figma-ux-researcher.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Figma operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Figma values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Figma is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Figma is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Figma tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Figma is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Figma values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Figma uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Figma is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-genentech-data-engineer.json
+++ b/data/generated/modules/company-role-genentech-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Genentech operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Genentech values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Genentech is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Genentech is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Genentech tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Genentech is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Genentech values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Genentech uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Genentech is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-genentech-data-scientist.json
+++ b/data/generated/modules/company-role-genentech-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Genentech operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Genentech values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Genentech is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Genentech is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Genentech tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Genentech is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Genentech values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Genentech uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Genentech is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-genentech-engineering-manager.json
+++ b/data/generated/modules/company-role-genentech-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Genentech operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Genentech values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Genentech is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Genentech is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Genentech tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Genentech is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Genentech values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Genentech uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Genentech is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-genentech-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-genentech-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Genentech operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Genentech values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Genentech is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Genentech is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Genentech tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Genentech is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Genentech values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Genentech uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Genentech is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-genentech-software-engineer.json
+++ b/data/generated/modules/company-role-genentech-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Genentech operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Genentech values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Genentech is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upda..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Genentech uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questi..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Genentech tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Genentech is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Genentech values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Genentech uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Genentech is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-goldman-sachs-backend-engineer.json
+++ b/data/generated/modules/company-role-goldman-sachs-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Goldman Sachs operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-questi..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Goldman Sachs values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Goldman Sachs is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd w..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Goldman Sachs is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, no..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Goldman Sachs tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cu..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Goldman Sachs is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resiste..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Goldman Sachs uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real pr..."
           }
         }
       ]

--- a/data/generated/modules/company-role-goldman-sachs-business-analyst.json
+++ b/data/generated/modules/company-role-goldman-sachs-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Goldman Sachs operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-questi..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Goldman Sachs values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Goldman Sachs is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd w..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Goldman Sachs is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, no..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Goldman Sachs tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cu..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Goldman Sachs is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resiste..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Goldman Sachs uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real pr..."
           }
         }
       ]

--- a/data/generated/modules/company-role-goldman-sachs-data-engineer.json
+++ b/data/generated/modules/company-role-goldman-sachs-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Goldman Sachs operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-questi..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Goldman Sachs values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Goldman Sachs is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd w..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Goldman Sachs is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, no..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Goldman Sachs tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cu..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Goldman Sachs is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resiste..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Goldman Sachs uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real pr..."
           }
         }
       ]

--- a/data/generated/modules/company-role-goldman-sachs-data-scientist.json
+++ b/data/generated/modules/company-role-goldman-sachs-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Goldman Sachs operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-questi..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Goldman Sachs values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Goldman Sachs is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd w..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Goldman Sachs is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, no..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Goldman Sachs tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cu..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Goldman Sachs is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resiste..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Goldman Sachs uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real pr..."
           }
         }
       ]

--- a/data/generated/modules/company-role-goldman-sachs-engineering-manager.json
+++ b/data/generated/modules/company-role-goldman-sachs-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Goldman Sachs operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-questi..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Goldman Sachs values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Goldman Sachs is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd w..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Goldman Sachs is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, no..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Goldman Sachs tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cu..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Goldman Sachs is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resiste..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Goldman Sachs uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real pr..."
           }
         }
       ]

--- a/data/generated/modules/company-role-goldman-sachs-financial-analyst.json
+++ b/data/generated/modules/company-role-goldman-sachs-financial-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Goldman Sachs operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-questi..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Goldman Sachs values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Goldman Sachs is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd w..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Goldman Sachs is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, no..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Goldman Sachs tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cu..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Goldman Sachs is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resiste..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Goldman Sachs uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real pr..."
           }
         }
       ]

--- a/data/generated/modules/company-role-goldman-sachs-product-manager.json
+++ b/data/generated/modules/company-role-goldman-sachs-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Goldman Sachs operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-questi..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Goldman Sachs values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Goldman Sachs isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing wi..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Goldman Sachs tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cu..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Goldman Sachs is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resiste..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Goldman Sachs uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real pr..."
           }
         }
       ]

--- a/data/generated/modules/company-role-goldman-sachs-security-engineer.json
+++ b/data/generated/modules/company-role-goldman-sachs-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Goldman Sachs operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-questi..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Goldman Sachs values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Goldman Sachs is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd w..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Goldman Sachs is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, no..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Goldman Sachs tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cu..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Goldman Sachs is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resiste..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Goldman Sachs uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real pr..."
           }
         }
       ]

--- a/data/generated/modules/company-role-goldman-sachs-software-engineer.json
+++ b/data/generated/modules/company-role-goldman-sachs-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Goldman Sachs operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-questi..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Goldman Sachs values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Goldman Sachs is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Goldman Sachs uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying qu..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Goldman Sachs tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cu..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Goldman Sachs is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resiste..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Goldman Sachs uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Goldman Sachs is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real pr..."
           }
         }
       ]

--- a/data/generated/modules/company-role-google-backend-engineer.json
+++ b/data/generated/modules/company-role-google-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Google operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Google values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Google is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Google is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Google tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Google is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Google uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-google-data-engineer.json
+++ b/data/generated/modules/company-role-google-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Google operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Google values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Google is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Google is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Google tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Google is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Google uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-google-data-scientist.json
+++ b/data/generated/modules/company-role-google-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Google operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Google values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Google is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Google is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Google tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Google is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Google uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-google-devops-engineer.json
+++ b/data/generated/modules/company-role-google-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Google operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Google values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Google is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Google is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Google tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Google is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Google uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-google-engineering-manager.json
+++ b/data/generated/modules/company-role-google-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Google operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Google values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Google is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Google is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Google tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Google is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Google uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-google-frontend-engineer.json
+++ b/data/generated/modules/company-role-google-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Google operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Google values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Google is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Google is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Google tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Google is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Google uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-google-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-google-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Google operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Google values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Google is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Google is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Google tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Google is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Google uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-google-mobile-engineer.json
+++ b/data/generated/modules/company-role-google-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Google operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Google values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Google is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Google is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Google tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Google is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Google uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-google-product-designer.json
+++ b/data/generated/modules/company-role-google-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Google operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Google values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Google is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Google is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Google tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Google is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Google uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-google-product-manager.json
+++ b/data/generated/modules/company-role-google-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Google operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Google values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Google isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Google tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Google is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Google uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-google-security-engineer.json
+++ b/data/generated/modules/company-role-google-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Google operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Google values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Google is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Google is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Google tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Google is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Google uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-google-software-engineer.json
+++ b/data/generated/modules/company-role-google-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Google operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Google values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Google is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Google uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Google tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Google is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Google uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-google-solutions-architect.json
+++ b/data/generated/modules/company-role-google-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Google operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Google values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Google is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Google is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Google tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Google is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Google uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-google-technical-program-manager.json
+++ b/data/generated/modules/company-role-google-technical-program-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Google operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Google values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Google is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Google is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Google tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Google is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Google uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-google-ux-researcher.json
+++ b/data/generated/modules/company-role-google-ux-researcher.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Google operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Google values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Google is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Google is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Google tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Google is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Google uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Google is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-home-depot-backend-engineer.json
+++ b/data/generated/modules/company-role-home-depot-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Home Depot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Home Depot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Home Depot is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Home Depot is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Home Depot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Home Depot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Home Depot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Home Depot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Home Depot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-home-depot-business-analyst.json
+++ b/data/generated/modules/company-role-home-depot-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Home Depot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Home Depot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Home Depot is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Home Depot is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Home Depot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Home Depot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Home Depot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Home Depot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Home Depot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-home-depot-data-engineer.json
+++ b/data/generated/modules/company-role-home-depot-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Home Depot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Home Depot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Home Depot is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Home Depot is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Home Depot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Home Depot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Home Depot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Home Depot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Home Depot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-home-depot-data-scientist.json
+++ b/data/generated/modules/company-role-home-depot-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Home Depot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Home Depot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Home Depot is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Home Depot is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Home Depot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Home Depot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Home Depot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Home Depot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Home Depot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-home-depot-engineering-manager.json
+++ b/data/generated/modules/company-role-home-depot-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Home Depot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Home Depot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Home Depot is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Home Depot is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Home Depot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Home Depot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Home Depot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Home Depot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Home Depot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-home-depot-product-manager.json
+++ b/data/generated/modules/company-role-home-depot-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Home Depot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Home Depot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Home Depot isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing witho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Home Depot is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I jus..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Home Depot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Home Depot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Home Depot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Home Depot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Home Depot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-home-depot-software-engineer.json
+++ b/data/generated/modules/company-role-home-depot-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Home Depot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Home Depot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Home Depot is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Home Depot uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying quest..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Home Depot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Home Depot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Home Depot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Home Depot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Home Depot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-hubspot-account-executive.json
+++ b/data/generated/modules/company-role-hubspot-account-executive.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "HubSpot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. HubSpot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but HubSpot is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "HubSpot is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "HubSpot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but HubSpot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but HubSpot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-hubspot-backend-engineer.json
+++ b/data/generated/modules/company-role-hubspot-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "HubSpot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. HubSpot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but HubSpot is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "HubSpot is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "HubSpot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but HubSpot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but HubSpot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-hubspot-data-scientist.json
+++ b/data/generated/modules/company-role-hubspot-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "HubSpot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. HubSpot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but HubSpot is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "HubSpot is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "HubSpot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but HubSpot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but HubSpot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-hubspot-engineering-manager.json
+++ b/data/generated/modules/company-role-hubspot-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "HubSpot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. HubSpot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but HubSpot is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "HubSpot is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "HubSpot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but HubSpot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but HubSpot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-hubspot-frontend-engineer.json
+++ b/data/generated/modules/company-role-hubspot-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "HubSpot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. HubSpot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but HubSpot is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "HubSpot is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "HubSpot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but HubSpot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but HubSpot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-hubspot-marketing-manager.json
+++ b/data/generated/modules/company-role-hubspot-marketing-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "HubSpot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. HubSpot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but HubSpot is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "HubSpot is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "HubSpot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but HubSpot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but HubSpot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-hubspot-product-designer.json
+++ b/data/generated/modules/company-role-hubspot-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "HubSpot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. HubSpot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but HubSpot is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "HubSpot is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "HubSpot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but HubSpot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but HubSpot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-hubspot-product-manager.json
+++ b/data/generated/modules/company-role-hubspot-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "HubSpot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. HubSpot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but HubSpot isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just t..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "HubSpot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but HubSpot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but HubSpot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-hubspot-software-engineer.json
+++ b/data/generated/modules/company-role-hubspot-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "HubSpot operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. HubSpot values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. HubSpot is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key update..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but HubSpot uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying question..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "HubSpot tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but HubSpot is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but HubSpot uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "HubSpot is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ibm-backend-engineer.json
+++ b/data/generated/modules/company-role-ibm-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "IBM operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. IBM values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but IBM is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "IBM is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "IBM tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but IBM is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "IBM values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but IBM uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "IBM is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ibm-data-engineer.json
+++ b/data/generated/modules/company-role-ibm-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "IBM operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. IBM values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but IBM is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "IBM is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "IBM tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but IBM is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "IBM values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but IBM uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "IBM is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ibm-data-scientist.json
+++ b/data/generated/modules/company-role-ibm-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "IBM operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. IBM values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but IBM is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "IBM is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "IBM tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but IBM is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "IBM values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but IBM uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "IBM is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ibm-engineering-manager.json
+++ b/data/generated/modules/company-role-ibm-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "IBM operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. IBM values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but IBM is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "IBM is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "IBM tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but IBM is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "IBM values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but IBM uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "IBM is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ibm-product-manager.json
+++ b/data/generated/modules/company-role-ibm-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "IBM operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. IBM values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but IBM isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without show..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "IBM is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tell ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "IBM tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but IBM is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "IBM values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but IBM uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "IBM is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ibm-software-engineer.json
+++ b/data/generated/modules/company-role-ibm-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "IBM operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. IBM values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. IBM is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? T..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but IBM uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions or..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "IBM tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but IBM is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "IBM values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but IBM uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "IBM is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-ibm-solutions-architect.json
+++ b/data/generated/modules/company-role-ibm-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "IBM operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. IBM values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but IBM is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "IBM is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "IBM tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but IBM is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "IBM values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but IBM uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "IBM is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-illumina-data-engineer.json
+++ b/data/generated/modules/company-role-illumina-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Illumina operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Illumina values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Illumina is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Illumina is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Illumina tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Illumina is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Illumina values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Illumina uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Illumina is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-illumina-data-scientist.json
+++ b/data/generated/modules/company-role-illumina-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Illumina operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Illumina values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Illumina is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Illumina is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Illumina tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Illumina is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Illumina values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Illumina uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Illumina is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-illumina-engineering-manager.json
+++ b/data/generated/modules/company-role-illumina-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Illumina operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Illumina values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Illumina is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Illumina is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Illumina tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Illumina is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Illumina values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Illumina uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Illumina is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-illumina-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-illumina-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Illumina operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Illumina values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Illumina is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Illumina is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Illumina tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Illumina is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Illumina values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Illumina uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Illumina is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-illumina-software-engineer.json
+++ b/data/generated/modules/company-role-illumina-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Illumina operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Illumina values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Illumina is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updat..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Illumina uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questio..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Illumina tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Illumina is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Illumina values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Illumina uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Illumina is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-instacart-backend-engineer.json
+++ b/data/generated/modules/company-role-instacart-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Instacart operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Instacart values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Instacart is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Instacart is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Instacart tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Instacart is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Instacart uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-instacart-data-engineer.json
+++ b/data/generated/modules/company-role-instacart-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Instacart operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Instacart values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Instacart is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Instacart is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Instacart tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Instacart is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Instacart uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-instacart-data-scientist.json
+++ b/data/generated/modules/company-role-instacart-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Instacart operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Instacart values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Instacart is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Instacart is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Instacart tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Instacart is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Instacart uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-instacart-engineering-manager.json
+++ b/data/generated/modules/company-role-instacart-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Instacart operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Instacart values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Instacart is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Instacart is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Instacart tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Instacart is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Instacart uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-instacart-mobile-engineer.json
+++ b/data/generated/modules/company-role-instacart-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Instacart operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Instacart values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Instacart is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Instacart is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Instacart tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Instacart is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Instacart uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-instacart-product-designer.json
+++ b/data/generated/modules/company-role-instacart-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Instacart operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Instacart values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Instacart is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Instacart is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Instacart tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Instacart is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Instacart uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-instacart-product-manager.json
+++ b/data/generated/modules/company-role-instacart-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Instacart operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Instacart values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Instacart isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing withou..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Instacart tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Instacart is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Instacart uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-instacart-software-engineer.json
+++ b/data/generated/modules/company-role-instacart-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Instacart operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Instacart values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Instacart is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upda..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Instacart uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questi..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Instacart tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Instacart is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Instacart uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Instacart is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-intel-backend-engineer.json
+++ b/data/generated/modules/company-role-intel-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Intel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Intel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Intel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Intel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Intel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Intel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Intel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-intel-data-engineer.json
+++ b/data/generated/modules/company-role-intel-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Intel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Intel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Intel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Intel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Intel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Intel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Intel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-intel-data-scientist.json
+++ b/data/generated/modules/company-role-intel-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Intel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Intel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Intel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Intel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Intel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Intel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Intel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-intel-devops-engineer.json
+++ b/data/generated/modules/company-role-intel-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Intel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Intel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Intel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Intel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Intel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Intel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Intel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-intel-engineering-manager.json
+++ b/data/generated/modules/company-role-intel-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Intel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Intel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Intel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Intel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Intel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Intel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Intel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-intel-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-intel-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Intel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Intel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Intel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Intel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Intel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Intel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Intel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-intel-product-manager.json
+++ b/data/generated/modules/company-role-intel-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Intel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Intel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Intel isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sh..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tel..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Intel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Intel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Intel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-intel-qa-engineer.json
+++ b/data/generated/modules/company-role-intel-qa-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Intel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Intel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Intel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Intel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Intel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Intel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Intel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-intel-security-engineer.json
+++ b/data/generated/modules/company-role-intel-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Intel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Intel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Intel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Intel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Intel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Intel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Intel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-intel-software-engineer.json
+++ b/data/generated/modules/company-role-intel-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Intel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Intel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Intel is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates?..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Intel uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Intel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Intel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Intel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Intel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jane-street-backend-engineer.json
+++ b/data/generated/modules/company-role-jane-street-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Jane Street operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Jane Street values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do yo..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Jane Street is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd wan..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Jane Street is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Jane Street tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cust..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Jane Street is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be ho..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Jane Street values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Jane Street uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to l..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Jane Street is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real prob..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jane-street-data-engineer.json
+++ b/data/generated/modules/company-role-jane-street-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Jane Street operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Jane Street values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do yo..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Jane Street is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd wan..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Jane Street is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Jane Street tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cust..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Jane Street is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be ho..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Jane Street values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Jane Street uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to l..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Jane Street is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real prob..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jane-street-data-scientist.json
+++ b/data/generated/modules/company-role-jane-street-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Jane Street operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Jane Street values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do yo..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Jane Street is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd wan..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Jane Street is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Jane Street tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cust..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Jane Street is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be ho..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Jane Street values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Jane Street uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to l..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Jane Street is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real prob..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jane-street-financial-analyst.json
+++ b/data/generated/modules/company-role-jane-street-financial-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Jane Street operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Jane Street values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do yo..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Jane Street is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd wan..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Jane Street is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Jane Street tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cust..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Jane Street is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be ho..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Jane Street values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Jane Street uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to l..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Jane Street is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real prob..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jane-street-software-engineer.json
+++ b/data/generated/modules/company-role-jane-street-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Jane Street operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Jane Street values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do yo..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Jane Street is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key up..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Jane Street uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying ques..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Jane Street tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the cust..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Jane Street is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be ho..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Jane Street values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Jane Street uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to l..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Jane Street is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real prob..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jnj-business-analyst.json
+++ b/data/generated/modules/company-role-jnj-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Johnson & Johnson operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-qu..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Johnson & Johnson values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior?..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Johnson & Johnson is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Johnson & Johnson is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Johnson & Johnson tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Johnson & Johnson is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Johnson & Johnson values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or res..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Johnson & Johnson uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wan..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Johnson & Johnson is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the rea..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jnj-data-engineer.json
+++ b/data/generated/modules/company-role-jnj-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Johnson & Johnson operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-qu..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Johnson & Johnson values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior?..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Johnson & Johnson is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Johnson & Johnson is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Johnson & Johnson tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Johnson & Johnson is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Johnson & Johnson values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or res..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Johnson & Johnson uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wan..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Johnson & Johnson is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the rea..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jnj-data-scientist.json
+++ b/data/generated/modules/company-role-jnj-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Johnson & Johnson operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-qu..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Johnson & Johnson values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior?..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Johnson & Johnson is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Johnson & Johnson is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Johnson & Johnson tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Johnson & Johnson is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Johnson & Johnson values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or res..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Johnson & Johnson uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wan..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Johnson & Johnson is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the rea..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jnj-engineering-manager.json
+++ b/data/generated/modules/company-role-jnj-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Johnson & Johnson operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-qu..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Johnson & Johnson values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior?..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Johnson & Johnson is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Johnson & Johnson is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Johnson & Johnson tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Johnson & Johnson is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Johnson & Johnson values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or res..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Johnson & Johnson uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wan..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Johnson & Johnson is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the rea..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jnj-product-manager.json
+++ b/data/generated/modules/company-role-jnj-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Johnson & Johnson operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-qu..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Johnson & Johnson values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior?..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Johnson & Johnson isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessin..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Johnson & Johnson is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Johnson & Johnson tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Johnson & Johnson is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Johnson & Johnson values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or res..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Johnson & Johnson uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wan..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Johnson & Johnson is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the rea..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jnj-software-engineer.json
+++ b/data/generated/modules/company-role-jnj-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Johnson & Johnson operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-qu..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Johnson & Johnson values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior?..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Johnson & Johnson is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Johnson & Johnson uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifyin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Johnson & Johnson tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve th..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Johnson & Johnson is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Johnson & Johnson values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or res..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Johnson & Johnson uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wan..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Johnson & Johnson is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the rea..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jpmorgan-backend-engineer.json
+++ b/data/generated/modules/company-role-jpmorgan-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "JPMorgan Chase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. JPMorgan Chase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but JPMorgan Chase is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "JPMorgan Chase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but JPMorgan Chase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but JPMorgan Chase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jpmorgan-business-analyst.json
+++ b/data/generated/modules/company-role-jpmorgan-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "JPMorgan Chase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. JPMorgan Chase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but JPMorgan Chase is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "JPMorgan Chase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but JPMorgan Chase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but JPMorgan Chase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jpmorgan-data-engineer.json
+++ b/data/generated/modules/company-role-jpmorgan-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "JPMorgan Chase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. JPMorgan Chase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but JPMorgan Chase is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "JPMorgan Chase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but JPMorgan Chase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but JPMorgan Chase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jpmorgan-data-scientist.json
+++ b/data/generated/modules/company-role-jpmorgan-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "JPMorgan Chase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. JPMorgan Chase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but JPMorgan Chase is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "JPMorgan Chase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but JPMorgan Chase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but JPMorgan Chase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jpmorgan-engineering-manager.json
+++ b/data/generated/modules/company-role-jpmorgan-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "JPMorgan Chase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. JPMorgan Chase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but JPMorgan Chase is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "JPMorgan Chase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but JPMorgan Chase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but JPMorgan Chase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jpmorgan-financial-analyst.json
+++ b/data/generated/modules/company-role-jpmorgan-financial-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "JPMorgan Chase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. JPMorgan Chase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but JPMorgan Chase is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "JPMorgan Chase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but JPMorgan Chase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but JPMorgan Chase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jpmorgan-product-manager.json
+++ b/data/generated/modules/company-role-jpmorgan-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "JPMorgan Chase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. JPMorgan Chase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but JPMorgan Chase isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing w..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "JPMorgan Chase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but JPMorgan Chase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but JPMorgan Chase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jpmorgan-security-engineer.json
+++ b/data/generated/modules/company-role-jpmorgan-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "JPMorgan Chase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. JPMorgan Chase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but JPMorgan Chase is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "JPMorgan Chase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but JPMorgan Chase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but JPMorgan Chase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-jpmorgan-software-engineer.json
+++ b/data/generated/modules/company-role-jpmorgan-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "JPMorgan Chase operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. JPMorgan Chase values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. JPMorgan Chase is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but JPMorgan Chase uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying q..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "JPMorgan Chase tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but JPMorgan Chase is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but JPMorgan Chase uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "JPMorgan Chase is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-kpmg-business-analyst.json
+++ b/data/generated/modules/company-role-kpmg-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "KPMG operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. KPMG values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but KPMG is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "KPMG is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "KPMG tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but KPMG is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "KPMG values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but KPMG uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "KPMG is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-kpmg-data-scientist.json
+++ b/data/generated/modules/company-role-kpmg-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "KPMG operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. KPMG values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but KPMG is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "KPMG is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "KPMG tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but KPMG is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "KPMG values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but KPMG uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "KPMG is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-kpmg-financial-analyst.json
+++ b/data/generated/modules/company-role-kpmg-financial-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "KPMG operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. KPMG values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but KPMG is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "KPMG is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "KPMG tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but KPMG is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "KPMG values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but KPMG uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "KPMG is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-kpmg-management-consultant.json
+++ b/data/generated/modules/company-role-kpmg-management-consultant.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "KPMG operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. KPMG values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but KPMG is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "KPMG is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "KPMG tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but KPMG is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "KPMG values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but KPMG uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "KPMG is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-kpmg-software-engineer.json
+++ b/data/generated/modules/company-role-kpmg-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "KPMG operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. KPMG values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. KPMG is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but KPMG uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions o..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "KPMG tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but KPMG is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "KPMG values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but KPMG uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "KPMG is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-linkedin-backend-engineer.json
+++ b/data/generated/modules/company-role-linkedin-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "LinkedIn operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. LinkedIn values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but LinkedIn is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "LinkedIn is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "LinkedIn tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but LinkedIn is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but LinkedIn uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-linkedin-data-engineer.json
+++ b/data/generated/modules/company-role-linkedin-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "LinkedIn operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. LinkedIn values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but LinkedIn is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "LinkedIn is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "LinkedIn tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but LinkedIn is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but LinkedIn uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-linkedin-data-scientist.json
+++ b/data/generated/modules/company-role-linkedin-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "LinkedIn operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. LinkedIn values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but LinkedIn is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "LinkedIn is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "LinkedIn tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but LinkedIn is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but LinkedIn uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-linkedin-engineering-manager.json
+++ b/data/generated/modules/company-role-linkedin-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "LinkedIn operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. LinkedIn values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but LinkedIn is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "LinkedIn is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "LinkedIn tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but LinkedIn is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but LinkedIn uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-linkedin-frontend-engineer.json
+++ b/data/generated/modules/company-role-linkedin-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "LinkedIn operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. LinkedIn values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but LinkedIn is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "LinkedIn is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "LinkedIn tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but LinkedIn is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but LinkedIn uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-linkedin-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-linkedin-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "LinkedIn operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. LinkedIn values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but LinkedIn is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "LinkedIn is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "LinkedIn tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but LinkedIn is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but LinkedIn uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-linkedin-mobile-engineer.json
+++ b/data/generated/modules/company-role-linkedin-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "LinkedIn operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. LinkedIn values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but LinkedIn is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "LinkedIn is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "LinkedIn tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but LinkedIn is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but LinkedIn uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-linkedin-product-designer.json
+++ b/data/generated/modules/company-role-linkedin-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "LinkedIn operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. LinkedIn values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but LinkedIn is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "LinkedIn is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "LinkedIn tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but LinkedIn is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but LinkedIn uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-linkedin-product-manager.json
+++ b/data/generated/modules/company-role-linkedin-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "LinkedIn operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. LinkedIn values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but LinkedIn isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "LinkedIn tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but LinkedIn is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but LinkedIn uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-linkedin-software-engineer.json
+++ b/data/generated/modules/company-role-linkedin-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "LinkedIn operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. LinkedIn values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. LinkedIn is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updat..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but LinkedIn uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questio..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "LinkedIn tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but LinkedIn is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but LinkedIn uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "LinkedIn is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lululemon-backend-engineer.json
+++ b/data/generated/modules/company-role-lululemon-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lululemon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lululemon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Lululemon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Lululemon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lululemon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lululemon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lululemon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lululemon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lululemon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lululemon-data-scientist.json
+++ b/data/generated/modules/company-role-lululemon-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lululemon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lululemon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Lululemon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Lululemon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lululemon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lululemon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lululemon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lululemon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lululemon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lululemon-frontend-engineer.json
+++ b/data/generated/modules/company-role-lululemon-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lululemon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lululemon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Lululemon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Lululemon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lululemon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lululemon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lululemon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lululemon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lululemon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lululemon-marketing-manager.json
+++ b/data/generated/modules/company-role-lululemon-marketing-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lululemon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lululemon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Lululemon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Lululemon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lululemon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lululemon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lululemon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lululemon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lululemon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lululemon-product-designer.json
+++ b/data/generated/modules/company-role-lululemon-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lululemon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lululemon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Lululemon is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Lululemon is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lululemon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lululemon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lululemon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lululemon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lululemon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lululemon-product-manager.json
+++ b/data/generated/modules/company-role-lululemon-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lululemon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lululemon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Lululemon isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing withou..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lululemon is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lululemon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lululemon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lululemon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lululemon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lululemon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lululemon-software-engineer.json
+++ b/data/generated/modules/company-role-lululemon-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lululemon operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lululemon values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Lululemon is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upda..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Lululemon uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questi..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lululemon tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lululemon is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lululemon values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lululemon uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lululemon is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lyft-backend-engineer.json
+++ b/data/generated/modules/company-role-lyft-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lyft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lyft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Lyft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Lyft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lyft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lyft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lyft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lyft-data-engineer.json
+++ b/data/generated/modules/company-role-lyft-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lyft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lyft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Lyft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Lyft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lyft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lyft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lyft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lyft-data-scientist.json
+++ b/data/generated/modules/company-role-lyft-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lyft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lyft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Lyft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Lyft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lyft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lyft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lyft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lyft-engineering-manager.json
+++ b/data/generated/modules/company-role-lyft-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lyft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lyft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Lyft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Lyft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lyft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lyft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lyft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lyft-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-lyft-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lyft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lyft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Lyft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Lyft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lyft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lyft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lyft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lyft-mobile-engineer.json
+++ b/data/generated/modules/company-role-lyft-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lyft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lyft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Lyft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Lyft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lyft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lyft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lyft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lyft-product-designer.json
+++ b/data/generated/modules/company-role-lyft-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lyft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lyft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Lyft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Lyft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lyft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lyft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lyft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lyft-product-manager.json
+++ b/data/generated/modules/company-role-lyft-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lyft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lyft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Lyft isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tell..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lyft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lyft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lyft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-lyft-software-engineer.json
+++ b/data/generated/modules/company-role-lyft-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Lyft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Lyft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Lyft is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Lyft uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions o..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Lyft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Lyft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Lyft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Lyft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mastercard-backend-engineer.json
+++ b/data/generated/modules/company-role-mastercard-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Mastercard operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Mastercard values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Mastercard is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Mastercard is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Mastercard tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Mastercard is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Mastercard values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Mastercard uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Mastercard is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mastercard-data-engineer.json
+++ b/data/generated/modules/company-role-mastercard-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Mastercard operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Mastercard values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Mastercard is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Mastercard is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Mastercard tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Mastercard is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Mastercard values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Mastercard uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Mastercard is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mastercard-data-scientist.json
+++ b/data/generated/modules/company-role-mastercard-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Mastercard operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Mastercard values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Mastercard is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Mastercard is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Mastercard tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Mastercard is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Mastercard values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Mastercard uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Mastercard is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mastercard-engineering-manager.json
+++ b/data/generated/modules/company-role-mastercard-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Mastercard operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Mastercard values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Mastercard is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Mastercard is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Mastercard tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Mastercard is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Mastercard values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Mastercard uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Mastercard is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mastercard-product-manager.json
+++ b/data/generated/modules/company-role-mastercard-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Mastercard operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Mastercard values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Mastercard isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing witho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Mastercard is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I jus..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Mastercard tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Mastercard is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Mastercard values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Mastercard uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Mastercard is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mastercard-security-engineer.json
+++ b/data/generated/modules/company-role-mastercard-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Mastercard operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Mastercard values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Mastercard is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Mastercard is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Mastercard tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Mastercard is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Mastercard values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Mastercard uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Mastercard is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mastercard-software-engineer.json
+++ b/data/generated/modules/company-role-mastercard-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Mastercard operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Mastercard values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Mastercard is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Mastercard uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying quest..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Mastercard tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Mastercard is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Mastercard values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Mastercard uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Mastercard is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mckinsey-business-analyst.json
+++ b/data/generated/modules/company-role-mckinsey-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "McKinsey & Company operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-q..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. McKinsey & Company values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but McKinsey & Company is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when the..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "McKinsey & Company is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterativ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "McKinsey & Company tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but McKinsey & Company is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "McKinsey & Company values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or re..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but McKinsey & Company uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wa..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "McKinsey & Company is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the re..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mckinsey-data-scientist.json
+++ b/data/generated/modules/company-role-mckinsey-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "McKinsey & Company operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-q..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. McKinsey & Company values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but McKinsey & Company is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when the..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "McKinsey & Company is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterativ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "McKinsey & Company tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but McKinsey & Company is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "McKinsey & Company values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or re..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but McKinsey & Company uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wa..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "McKinsey & Company is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the re..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mckinsey-management-consultant.json
+++ b/data/generated/modules/company-role-mckinsey-management-consultant.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "McKinsey & Company operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-q..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. McKinsey & Company values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but McKinsey & Company is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when the..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "McKinsey & Company is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterativ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "McKinsey & Company tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but McKinsey & Company is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "McKinsey & Company values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or re..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but McKinsey & Company uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wa..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "McKinsey & Company is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the re..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mckinsey-product-manager.json
+++ b/data/generated/modules/company-role-mckinsey-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "McKinsey & Company operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-q..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. McKinsey & Company values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but McKinsey & Company isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessi..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "McKinsey & Company is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is eithe..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "McKinsey & Company tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but McKinsey & Company is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "McKinsey & Company values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or re..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but McKinsey & Company uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wa..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "McKinsey & Company is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the re..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mckinsey-software-engineer.json
+++ b/data/generated/modules/company-role-mckinsey-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "McKinsey & Company operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-q..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. McKinsey & Company values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. McKinsey & Company is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but McKinsey & Company uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifyi..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "McKinsey & Company tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but McKinsey & Company is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "McKinsey & Company values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or re..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but McKinsey & Company uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wa..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "McKinsey & Company is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the re..."
           }
         }
       ]

--- a/data/generated/modules/company-role-meta-backend-engineer.json
+++ b/data/generated/modules/company-role-meta-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Meta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Meta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Meta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Meta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Meta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Meta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Meta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-meta-data-engineer.json
+++ b/data/generated/modules/company-role-meta-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Meta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Meta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Meta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Meta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Meta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Meta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Meta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-meta-data-scientist.json
+++ b/data/generated/modules/company-role-meta-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Meta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Meta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Meta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Meta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Meta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Meta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Meta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-meta-devops-engineer.json
+++ b/data/generated/modules/company-role-meta-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Meta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Meta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Meta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Meta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Meta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Meta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Meta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-meta-engineering-manager.json
+++ b/data/generated/modules/company-role-meta-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Meta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Meta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Meta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Meta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Meta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Meta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Meta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-meta-frontend-engineer.json
+++ b/data/generated/modules/company-role-meta-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Meta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Meta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Meta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Meta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Meta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Meta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Meta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-meta-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-meta-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Meta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Meta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Meta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Meta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Meta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Meta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Meta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-meta-mobile-engineer.json
+++ b/data/generated/modules/company-role-meta-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Meta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Meta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Meta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Meta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Meta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Meta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Meta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-meta-product-designer.json
+++ b/data/generated/modules/company-role-meta-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Meta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Meta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Meta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Meta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Meta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Meta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Meta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-meta-product-manager.json
+++ b/data/generated/modules/company-role-meta-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Meta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Meta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Meta isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tell..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Meta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Meta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Meta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-meta-security-engineer.json
+++ b/data/generated/modules/company-role-meta-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Meta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Meta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Meta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Meta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Meta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Meta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Meta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-meta-software-engineer.json
+++ b/data/generated/modules/company-role-meta-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Meta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Meta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Meta is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Meta uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions o..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Meta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Meta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Meta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-meta-technical-program-manager.json
+++ b/data/generated/modules/company-role-meta-technical-program-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Meta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Meta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Meta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Meta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Meta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Meta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Meta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-meta-ux-researcher.json
+++ b/data/generated/modules/company-role-meta-ux-researcher.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Meta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Meta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Meta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Meta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Meta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Meta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Meta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Meta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-microsoft-backend-engineer.json
+++ b/data/generated/modules/company-role-microsoft-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Microsoft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Microsoft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Microsoft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Microsoft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Microsoft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Microsoft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Microsoft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-microsoft-data-engineer.json
+++ b/data/generated/modules/company-role-microsoft-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Microsoft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Microsoft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Microsoft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Microsoft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Microsoft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Microsoft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Microsoft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-microsoft-data-scientist.json
+++ b/data/generated/modules/company-role-microsoft-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Microsoft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Microsoft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Microsoft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Microsoft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Microsoft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Microsoft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Microsoft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-microsoft-devops-engineer.json
+++ b/data/generated/modules/company-role-microsoft-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Microsoft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Microsoft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Microsoft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Microsoft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Microsoft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Microsoft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Microsoft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-microsoft-engineering-manager.json
+++ b/data/generated/modules/company-role-microsoft-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Microsoft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Microsoft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Microsoft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Microsoft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Microsoft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Microsoft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Microsoft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-microsoft-frontend-engineer.json
+++ b/data/generated/modules/company-role-microsoft-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Microsoft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Microsoft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Microsoft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Microsoft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Microsoft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Microsoft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Microsoft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-microsoft-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-microsoft-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Microsoft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Microsoft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Microsoft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Microsoft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Microsoft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Microsoft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Microsoft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-microsoft-product-designer.json
+++ b/data/generated/modules/company-role-microsoft-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Microsoft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Microsoft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Microsoft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Microsoft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Microsoft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Microsoft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Microsoft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-microsoft-product-manager.json
+++ b/data/generated/modules/company-role-microsoft-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Microsoft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Microsoft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Microsoft isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing withou..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Microsoft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Microsoft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Microsoft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-microsoft-security-engineer.json
+++ b/data/generated/modules/company-role-microsoft-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Microsoft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Microsoft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Microsoft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Microsoft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Microsoft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Microsoft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Microsoft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-microsoft-software-engineer.json
+++ b/data/generated/modules/company-role-microsoft-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Microsoft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Microsoft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Microsoft is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upda..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Microsoft uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questi..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Microsoft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Microsoft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Microsoft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-microsoft-solutions-architect.json
+++ b/data/generated/modules/company-role-microsoft-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Microsoft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Microsoft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Microsoft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Microsoft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Microsoft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Microsoft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Microsoft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-microsoft-technical-program-manager.json
+++ b/data/generated/modules/company-role-microsoft-technical-program-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Microsoft operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Microsoft values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Microsoft is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Microsoft is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Microsoft tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Microsoft is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Microsoft uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Microsoft is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-moderna-data-engineer.json
+++ b/data/generated/modules/company-role-moderna-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Moderna operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Moderna values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Moderna is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Moderna is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Moderna tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Moderna is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Moderna values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Moderna uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Moderna is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-moderna-data-scientist.json
+++ b/data/generated/modules/company-role-moderna-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Moderna operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Moderna values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Moderna is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Moderna is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Moderna tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Moderna is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Moderna values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Moderna uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Moderna is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-moderna-engineering-manager.json
+++ b/data/generated/modules/company-role-moderna-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Moderna operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Moderna values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Moderna is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Moderna is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Moderna tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Moderna is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Moderna values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Moderna uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Moderna is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-moderna-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-moderna-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Moderna operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Moderna values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Moderna is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Moderna is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Moderna tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Moderna is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Moderna values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Moderna uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Moderna is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-moderna-software-engineer.json
+++ b/data/generated/modules/company-role-moderna-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Moderna operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Moderna values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Moderna is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key update..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Moderna uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying question..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Moderna tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Moderna is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Moderna values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Moderna uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Moderna is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mongodb-backend-engineer.json
+++ b/data/generated/modules/company-role-mongodb-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "MongoDB operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. MongoDB values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but MongoDB is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "MongoDB is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "MongoDB tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but MongoDB is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "MongoDB values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but MongoDB uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "MongoDB is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mongodb-devops-engineer.json
+++ b/data/generated/modules/company-role-mongodb-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "MongoDB operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. MongoDB values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but MongoDB is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "MongoDB is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "MongoDB tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but MongoDB is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "MongoDB values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but MongoDB uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "MongoDB is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mongodb-engineering-manager.json
+++ b/data/generated/modules/company-role-mongodb-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "MongoDB operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. MongoDB values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but MongoDB is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "MongoDB is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "MongoDB tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but MongoDB is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "MongoDB values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but MongoDB uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "MongoDB is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mongodb-product-manager.json
+++ b/data/generated/modules/company-role-mongodb-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "MongoDB operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. MongoDB values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but MongoDB isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "MongoDB is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just t..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "MongoDB tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but MongoDB is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "MongoDB values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but MongoDB uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "MongoDB is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mongodb-sales-engineer.json
+++ b/data/generated/modules/company-role-mongodb-sales-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "MongoDB operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. MongoDB values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but MongoDB is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "MongoDB is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "MongoDB tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but MongoDB is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "MongoDB values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but MongoDB uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "MongoDB is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mongodb-software-engineer.json
+++ b/data/generated/modules/company-role-mongodb-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "MongoDB operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. MongoDB values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. MongoDB is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key update..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but MongoDB uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying question..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "MongoDB tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but MongoDB is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "MongoDB values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but MongoDB uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "MongoDB is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-mongodb-solutions-architect.json
+++ b/data/generated/modules/company-role-mongodb-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "MongoDB operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. MongoDB values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but MongoDB is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "MongoDB is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "MongoDB tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but MongoDB is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "MongoDB values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but MongoDB uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "MongoDB is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-morgan-stanley-backend-engineer.json
+++ b/data/generated/modules/company-role-morgan-stanley-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Morgan Stanley operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Morgan Stanley values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Morgan Stanley is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Morgan Stanley is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Morgan Stanley tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Morgan Stanley is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Morgan Stanley uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-morgan-stanley-business-analyst.json
+++ b/data/generated/modules/company-role-morgan-stanley-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Morgan Stanley operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Morgan Stanley values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Morgan Stanley is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Morgan Stanley is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Morgan Stanley tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Morgan Stanley is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Morgan Stanley uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-morgan-stanley-data-engineer.json
+++ b/data/generated/modules/company-role-morgan-stanley-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Morgan Stanley operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Morgan Stanley values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Morgan Stanley is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Morgan Stanley is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Morgan Stanley tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Morgan Stanley is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Morgan Stanley uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-morgan-stanley-data-scientist.json
+++ b/data/generated/modules/company-role-morgan-stanley-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Morgan Stanley operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Morgan Stanley values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Morgan Stanley is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Morgan Stanley is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Morgan Stanley tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Morgan Stanley is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Morgan Stanley uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-morgan-stanley-engineering-manager.json
+++ b/data/generated/modules/company-role-morgan-stanley-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Morgan Stanley operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Morgan Stanley values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Morgan Stanley is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Morgan Stanley is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Morgan Stanley tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Morgan Stanley is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Morgan Stanley uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-morgan-stanley-financial-analyst.json
+++ b/data/generated/modules/company-role-morgan-stanley-financial-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Morgan Stanley operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Morgan Stanley values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Morgan Stanley is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Morgan Stanley is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, n..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Morgan Stanley tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Morgan Stanley is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Morgan Stanley uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-morgan-stanley-product-manager.json
+++ b/data/generated/modules/company-role-morgan-stanley-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Morgan Stanley operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Morgan Stanley values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Morgan Stanley isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing w..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Morgan Stanley tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Morgan Stanley is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Morgan Stanley uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-morgan-stanley-software-engineer.json
+++ b/data/generated/modules/company-role-morgan-stanley-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Morgan Stanley operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-quest..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Morgan Stanley values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Morgan Stanley is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Morgan Stanley uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying q..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Morgan Stanley tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the c..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Morgan Stanley is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resist..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Morgan Stanley uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Morgan Stanley is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real p..."
           }
         }
       ]

--- a/data/generated/modules/company-role-netflix-backend-engineer.json
+++ b/data/generated/modules/company-role-netflix-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Netflix operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Netflix values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Netflix is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Netflix is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Netflix tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Netflix is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Netflix uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-netflix-data-engineer.json
+++ b/data/generated/modules/company-role-netflix-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Netflix operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Netflix values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Netflix is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Netflix is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Netflix tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Netflix is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Netflix uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-netflix-data-scientist.json
+++ b/data/generated/modules/company-role-netflix-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Netflix operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Netflix values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Netflix is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Netflix is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Netflix tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Netflix is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Netflix uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-netflix-devops-engineer.json
+++ b/data/generated/modules/company-role-netflix-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Netflix operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Netflix values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Netflix is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Netflix is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Netflix tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Netflix is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Netflix uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-netflix-engineering-manager.json
+++ b/data/generated/modules/company-role-netflix-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Netflix operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Netflix values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Netflix is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Netflix is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Netflix tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Netflix is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Netflix uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-netflix-frontend-engineer.json
+++ b/data/generated/modules/company-role-netflix-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Netflix operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Netflix values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Netflix is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Netflix is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Netflix tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Netflix is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Netflix uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-netflix-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-netflix-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Netflix operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Netflix values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Netflix is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Netflix is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Netflix tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Netflix is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Netflix uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-netflix-product-designer.json
+++ b/data/generated/modules/company-role-netflix-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Netflix operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Netflix values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Netflix is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Netflix is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Netflix tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Netflix is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Netflix uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-netflix-product-manager.json
+++ b/data/generated/modules/company-role-netflix-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Netflix operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Netflix values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Netflix isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just t..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Netflix tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Netflix is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Netflix uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-netflix-security-engineer.json
+++ b/data/generated/modules/company-role-netflix-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Netflix operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Netflix values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Netflix is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Netflix is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Netflix tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Netflix is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Netflix uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-netflix-software-engineer.json
+++ b/data/generated/modules/company-role-netflix-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Netflix operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Netflix values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Netflix is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key update..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Netflix uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying question..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Netflix tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Netflix is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Netflix uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Netflix is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nike-backend-engineer.json
+++ b/data/generated/modules/company-role-nike-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nike operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nike values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Nike is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Nike is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nike tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nike is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nike uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nike-data-scientist.json
+++ b/data/generated/modules/company-role-nike-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nike operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nike values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Nike is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Nike is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nike tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nike is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nike uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nike-engineering-manager.json
+++ b/data/generated/modules/company-role-nike-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nike operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nike values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Nike is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Nike is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nike tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nike is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nike uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nike-frontend-engineer.json
+++ b/data/generated/modules/company-role-nike-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nike operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nike values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Nike is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Nike is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nike tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nike is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nike uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nike-marketing-manager.json
+++ b/data/generated/modules/company-role-nike-marketing-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nike operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nike values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Nike is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Nike is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nike tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nike is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nike uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nike-mobile-engineer.json
+++ b/data/generated/modules/company-role-nike-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nike operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nike values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Nike is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Nike is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nike tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nike is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nike uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nike-product-designer.json
+++ b/data/generated/modules/company-role-nike-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nike operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nike values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Nike is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Nike is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nike tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nike is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nike uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nike-product-manager.json
+++ b/data/generated/modules/company-role-nike-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nike operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nike values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Nike isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tell..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nike tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nike is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nike uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nike-software-engineer.json
+++ b/data/generated/modules/company-role-nike-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nike operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nike values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Nike is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Nike uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions o..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nike tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nike is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nike uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nike is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-notion-backend-engineer.json
+++ b/data/generated/modules/company-role-notion-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Notion operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Notion values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Notion is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Notion is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Notion tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Notion is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Notion values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Notion uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Notion is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-notion-engineering-manager.json
+++ b/data/generated/modules/company-role-notion-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Notion operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Notion values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Notion is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Notion is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Notion tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Notion is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Notion values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Notion uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Notion is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-notion-frontend-engineer.json
+++ b/data/generated/modules/company-role-notion-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Notion operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Notion values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Notion is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Notion is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Notion tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Notion is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Notion values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Notion uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Notion is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-notion-product-designer.json
+++ b/data/generated/modules/company-role-notion-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Notion operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Notion values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Notion is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Notion is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Notion tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Notion is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Notion values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Notion uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Notion is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-notion-product-manager.json
+++ b/data/generated/modules/company-role-notion-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Notion operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Notion values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Notion isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Notion is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Notion tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Notion is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Notion values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Notion uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Notion is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-notion-software-engineer.json
+++ b/data/generated/modules/company-role-notion-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Notion operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Notion values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Notion is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Notion uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Notion tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Notion is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Notion values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Notion uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Notion is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-notion-ux-researcher.json
+++ b/data/generated/modules/company-role-notion-ux-researcher.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Notion operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Notion values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Notion is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Notion is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Notion tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Notion is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Notion values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Notion uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Notion is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nvidia-backend-engineer.json
+++ b/data/generated/modules/company-role-nvidia-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nvidia operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nvidia values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Nvidia is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Nvidia is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nvidia tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nvidia is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nvidia uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nvidia-data-engineer.json
+++ b/data/generated/modules/company-role-nvidia-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nvidia operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nvidia values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Nvidia is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Nvidia is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nvidia tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nvidia is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nvidia uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nvidia-data-scientist.json
+++ b/data/generated/modules/company-role-nvidia-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nvidia operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nvidia values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Nvidia is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Nvidia is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nvidia tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nvidia is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nvidia uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nvidia-devops-engineer.json
+++ b/data/generated/modules/company-role-nvidia-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nvidia operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nvidia values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Nvidia is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Nvidia is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nvidia tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nvidia is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nvidia uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nvidia-engineering-manager.json
+++ b/data/generated/modules/company-role-nvidia-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nvidia operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nvidia values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Nvidia is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Nvidia is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nvidia tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nvidia is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nvidia uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nvidia-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-nvidia-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nvidia operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nvidia values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Nvidia is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Nvidia is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nvidia tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nvidia is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nvidia uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nvidia-product-manager.json
+++ b/data/generated/modules/company-role-nvidia-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nvidia operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nvidia values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Nvidia isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nvidia tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nvidia is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nvidia uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nvidia-security-engineer.json
+++ b/data/generated/modules/company-role-nvidia-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nvidia operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nvidia values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Nvidia is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Nvidia is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nvidia tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nvidia is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nvidia uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nvidia-software-engineer.json
+++ b/data/generated/modules/company-role-nvidia-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nvidia operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nvidia values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Nvidia is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Nvidia uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nvidia tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nvidia is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nvidia uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-nvidia-solutions-architect.json
+++ b/data/generated/modules/company-role-nvidia-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Nvidia operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Nvidia values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Nvidia is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Nvidia is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Nvidia tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Nvidia is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Nvidia uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Nvidia is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-okta-backend-engineer.json
+++ b/data/generated/modules/company-role-okta-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Okta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Okta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Okta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Okta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Okta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Okta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Okta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Okta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Okta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-okta-devops-engineer.json
+++ b/data/generated/modules/company-role-okta-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Okta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Okta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Okta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Okta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Okta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Okta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Okta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Okta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Okta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-okta-engineering-manager.json
+++ b/data/generated/modules/company-role-okta-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Okta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Okta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Okta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Okta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Okta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Okta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Okta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Okta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Okta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-okta-product-manager.json
+++ b/data/generated/modules/company-role-okta-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Okta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Okta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Okta isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Okta is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tell..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Okta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Okta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Okta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Okta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Okta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-okta-security-engineer.json
+++ b/data/generated/modules/company-role-okta-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Okta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Okta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Okta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Okta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Okta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Okta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Okta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Okta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Okta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-okta-software-engineer.json
+++ b/data/generated/modules/company-role-okta-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Okta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Okta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Okta is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Okta uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions o..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Okta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Okta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Okta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Okta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Okta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-okta-solutions-architect.json
+++ b/data/generated/modules/company-role-okta-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Okta operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Okta values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Okta is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Okta is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Okta tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Okta is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Okta values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Okta uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Okta is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-optum-backend-engineer.json
+++ b/data/generated/modules/company-role-optum-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Optum operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Optum values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Optum is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Optum is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Optum tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Optum is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Optum values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Optum uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Optum is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-optum-business-analyst.json
+++ b/data/generated/modules/company-role-optum-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Optum operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Optum values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Optum is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Optum is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Optum tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Optum is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Optum values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Optum uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Optum is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-optum-data-engineer.json
+++ b/data/generated/modules/company-role-optum-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Optum operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Optum values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Optum is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Optum is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Optum tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Optum is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Optum values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Optum uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Optum is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-optum-data-scientist.json
+++ b/data/generated/modules/company-role-optum-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Optum operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Optum values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Optum is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Optum is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Optum tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Optum is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Optum values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Optum uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Optum is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-optum-engineering-manager.json
+++ b/data/generated/modules/company-role-optum-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Optum operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Optum values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Optum is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Optum is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Optum tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Optum is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Optum values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Optum uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Optum is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-optum-product-manager.json
+++ b/data/generated/modules/company-role-optum-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Optum operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Optum values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Optum isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sh..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Optum is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tel..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Optum tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Optum is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Optum values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Optum uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Optum is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-optum-software-engineer.json
+++ b/data/generated/modules/company-role-optum-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Optum operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Optum values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Optum is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates?..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Optum uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Optum tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Optum is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Optum values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Optum uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Optum is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-oracle-backend-engineer.json
+++ b/data/generated/modules/company-role-oracle-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Oracle operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Oracle values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Oracle is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Oracle is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Oracle tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Oracle is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Oracle uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-oracle-data-engineer.json
+++ b/data/generated/modules/company-role-oracle-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Oracle operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Oracle values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Oracle is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Oracle is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Oracle tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Oracle is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Oracle uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-oracle-data-scientist.json
+++ b/data/generated/modules/company-role-oracle-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Oracle operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Oracle values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Oracle is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Oracle is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Oracle tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Oracle is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Oracle uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-oracle-devops-engineer.json
+++ b/data/generated/modules/company-role-oracle-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Oracle operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Oracle values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Oracle is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Oracle is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Oracle tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Oracle is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Oracle uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-oracle-engineering-manager.json
+++ b/data/generated/modules/company-role-oracle-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Oracle operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Oracle values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Oracle is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Oracle is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Oracle tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Oracle is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Oracle uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-oracle-product-manager.json
+++ b/data/generated/modules/company-role-oracle-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Oracle operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Oracle values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Oracle isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Oracle tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Oracle is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Oracle uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-oracle-sales-engineer.json
+++ b/data/generated/modules/company-role-oracle-sales-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Oracle operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Oracle values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Oracle is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Oracle is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Oracle tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Oracle is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Oracle uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-oracle-software-engineer.json
+++ b/data/generated/modules/company-role-oracle-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Oracle operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Oracle values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Oracle is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Oracle uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Oracle tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Oracle is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Oracle uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-oracle-solutions-architect.json
+++ b/data/generated/modules/company-role-oracle-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Oracle operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Oracle values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Oracle is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Oracle is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Oracle tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Oracle is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Oracle uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Oracle is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-palantir-backend-engineer.json
+++ b/data/generated/modules/company-role-palantir-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Palantir operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Palantir values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Palantir is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Palantir is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Palantir tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Palantir is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Palantir values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Palantir uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Palantir is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-palantir-data-engineer.json
+++ b/data/generated/modules/company-role-palantir-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Palantir operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Palantir values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Palantir is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Palantir is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Palantir tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Palantir is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Palantir values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Palantir uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Palantir is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-palantir-data-scientist.json
+++ b/data/generated/modules/company-role-palantir-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Palantir operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Palantir values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Palantir is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Palantir is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Palantir tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Palantir is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Palantir values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Palantir uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Palantir is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-palantir-engineering-manager.json
+++ b/data/generated/modules/company-role-palantir-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Palantir operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Palantir values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Palantir is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Palantir is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Palantir tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Palantir is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Palantir values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Palantir uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Palantir is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-palantir-product-manager.json
+++ b/data/generated/modules/company-role-palantir-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Palantir operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Palantir values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Palantir isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Palantir is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Palantir tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Palantir is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Palantir values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Palantir uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Palantir is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-palantir-software-engineer.json
+++ b/data/generated/modules/company-role-palantir-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Palantir operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Palantir values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Palantir is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updat..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Palantir uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questio..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Palantir tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Palantir is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Palantir values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Palantir uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Palantir is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-palantir-solutions-architect.json
+++ b/data/generated/modules/company-role-palantir-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Palantir operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Palantir values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you t..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Palantir is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Palantir is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not lin..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Palantir tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custome..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Palantir is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hones..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Palantir values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it...."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Palantir uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lear..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Palantir is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem..."
           }
         }
       ]

--- a/data/generated/modules/company-role-paypal-backend-engineer.json
+++ b/data/generated/modules/company-role-paypal-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "PayPal operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. PayPal values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but PayPal is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "PayPal is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "PayPal tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but PayPal is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but PayPal uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-paypal-data-engineer.json
+++ b/data/generated/modules/company-role-paypal-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "PayPal operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. PayPal values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but PayPal is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "PayPal is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "PayPal tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but PayPal is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but PayPal uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-paypal-data-scientist.json
+++ b/data/generated/modules/company-role-paypal-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "PayPal operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. PayPal values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but PayPal is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "PayPal is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "PayPal tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but PayPal is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but PayPal uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-paypal-engineering-manager.json
+++ b/data/generated/modules/company-role-paypal-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "PayPal operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. PayPal values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but PayPal is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "PayPal is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "PayPal tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but PayPal is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but PayPal uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-paypal-mobile-engineer.json
+++ b/data/generated/modules/company-role-paypal-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "PayPal operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. PayPal values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but PayPal is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "PayPal is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "PayPal tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but PayPal is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but PayPal uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-paypal-product-designer.json
+++ b/data/generated/modules/company-role-paypal-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "PayPal operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. PayPal values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but PayPal is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "PayPal is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "PayPal tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but PayPal is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but PayPal uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-paypal-product-manager.json
+++ b/data/generated/modules/company-role-paypal-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "PayPal operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. PayPal values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but PayPal isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "PayPal tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but PayPal is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but PayPal uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-paypal-security-engineer.json
+++ b/data/generated/modules/company-role-paypal-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "PayPal operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. PayPal values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but PayPal is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "PayPal is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "PayPal tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but PayPal is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but PayPal uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-paypal-software-engineer.json
+++ b/data/generated/modules/company-role-paypal-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "PayPal operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. PayPal values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. PayPal is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but PayPal uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "PayPal tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but PayPal is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but PayPal uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PayPal is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pfizer-data-engineer.json
+++ b/data/generated/modules/company-role-pfizer-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Pfizer operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Pfizer values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Pfizer is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Pfizer is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Pfizer tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Pfizer is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pfizer values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Pfizer uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pfizer is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pfizer-data-scientist.json
+++ b/data/generated/modules/company-role-pfizer-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Pfizer operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Pfizer values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Pfizer is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Pfizer is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Pfizer tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Pfizer is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pfizer values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Pfizer uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pfizer is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pfizer-engineering-manager.json
+++ b/data/generated/modules/company-role-pfizer-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Pfizer operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Pfizer values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Pfizer is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Pfizer is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Pfizer tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Pfizer is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pfizer values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Pfizer uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pfizer is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pfizer-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-pfizer-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Pfizer operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Pfizer values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Pfizer is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Pfizer is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Pfizer tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Pfizer is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pfizer values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Pfizer uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pfizer is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pfizer-product-manager.json
+++ b/data/generated/modules/company-role-pfizer-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Pfizer operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Pfizer values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Pfizer isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pfizer is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Pfizer tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Pfizer is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pfizer values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Pfizer uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pfizer is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pfizer-software-engineer.json
+++ b/data/generated/modules/company-role-pfizer-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Pfizer operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Pfizer values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Pfizer is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Pfizer uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Pfizer tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Pfizer is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pfizer values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Pfizer uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pfizer is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pinterest-backend-engineer.json
+++ b/data/generated/modules/company-role-pinterest-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Pinterest operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Pinterest values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Pinterest is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Pinterest is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Pinterest tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Pinterest is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Pinterest uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pinterest-data-scientist.json
+++ b/data/generated/modules/company-role-pinterest-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Pinterest operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Pinterest values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Pinterest is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Pinterest is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Pinterest tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Pinterest is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Pinterest uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pinterest-engineering-manager.json
+++ b/data/generated/modules/company-role-pinterest-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Pinterest operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Pinterest values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Pinterest is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Pinterest is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Pinterest tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Pinterest is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Pinterest uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pinterest-frontend-engineer.json
+++ b/data/generated/modules/company-role-pinterest-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Pinterest operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Pinterest values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Pinterest is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Pinterest is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Pinterest tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Pinterest is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Pinterest uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pinterest-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-pinterest-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Pinterest operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Pinterest values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Pinterest is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Pinterest is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Pinterest tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Pinterest is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Pinterest uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pinterest-mobile-engineer.json
+++ b/data/generated/modules/company-role-pinterest-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Pinterest operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Pinterest values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Pinterest is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Pinterest is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Pinterest tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Pinterest is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Pinterest uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pinterest-product-designer.json
+++ b/data/generated/modules/company-role-pinterest-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Pinterest operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Pinterest values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Pinterest is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Pinterest is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Pinterest tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Pinterest is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Pinterest uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pinterest-product-manager.json
+++ b/data/generated/modules/company-role-pinterest-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Pinterest operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Pinterest values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Pinterest isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing withou..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Pinterest tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Pinterest is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Pinterest uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pinterest-software-engineer.json
+++ b/data/generated/modules/company-role-pinterest-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Pinterest operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Pinterest values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Pinterest is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upda..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Pinterest uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questi..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Pinterest tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Pinterest is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Pinterest uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Pinterest is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-plaid-backend-engineer.json
+++ b/data/generated/modules/company-role-plaid-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Plaid operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Plaid values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Plaid is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Plaid is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Plaid tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Plaid is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Plaid values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Plaid uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Plaid is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-plaid-data-scientist.json
+++ b/data/generated/modules/company-role-plaid-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Plaid operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Plaid values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Plaid is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Plaid is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Plaid tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Plaid is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Plaid values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Plaid uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Plaid is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-plaid-devops-engineer.json
+++ b/data/generated/modules/company-role-plaid-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Plaid operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Plaid values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Plaid is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Plaid is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Plaid tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Plaid is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Plaid values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Plaid uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Plaid is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-plaid-engineering-manager.json
+++ b/data/generated/modules/company-role-plaid-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Plaid operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Plaid values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Plaid is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Plaid is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Plaid tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Plaid is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Plaid values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Plaid uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Plaid is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-plaid-product-manager.json
+++ b/data/generated/modules/company-role-plaid-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Plaid operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Plaid values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Plaid isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sh..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Plaid is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tel..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Plaid tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Plaid is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Plaid values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Plaid uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Plaid is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-plaid-security-engineer.json
+++ b/data/generated/modules/company-role-plaid-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Plaid operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Plaid values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Plaid is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Plaid is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Plaid tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Plaid is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Plaid values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Plaid uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Plaid is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-plaid-software-engineer.json
+++ b/data/generated/modules/company-role-plaid-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Plaid operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Plaid values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Plaid is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates?..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Plaid uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Plaid tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Plaid is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Plaid values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Plaid uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Plaid is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pwc-business-analyst.json
+++ b/data/generated/modules/company-role-pwc-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "PwC operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. PwC values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but PwC is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "PwC is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "PwC tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but PwC is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PwC values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but PwC uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PwC is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pwc-data-scientist.json
+++ b/data/generated/modules/company-role-pwc-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "PwC operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. PwC values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but PwC is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "PwC is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "PwC tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but PwC is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PwC values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but PwC uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PwC is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pwc-financial-analyst.json
+++ b/data/generated/modules/company-role-pwc-financial-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "PwC operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. PwC values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but PwC is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "PwC is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "PwC tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but PwC is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PwC values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but PwC uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PwC is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pwc-management-consultant.json
+++ b/data/generated/modules/company-role-pwc-management-consultant.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "PwC operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. PwC values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but PwC is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "PwC is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "PwC tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but PwC is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PwC values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but PwC uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PwC is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-pwc-software-engineer.json
+++ b/data/generated/modules/company-role-pwc-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "PwC operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. PwC values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. PwC is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? T..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but PwC uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions or..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "PwC tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but PwC is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PwC values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but PwC uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "PwC is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-reddit-backend-engineer.json
+++ b/data/generated/modules/company-role-reddit-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Reddit operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Reddit values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Reddit is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Reddit is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Reddit tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Reddit is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Reddit uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-reddit-data-engineer.json
+++ b/data/generated/modules/company-role-reddit-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Reddit operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Reddit values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Reddit is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Reddit is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Reddit tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Reddit is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Reddit uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-reddit-data-scientist.json
+++ b/data/generated/modules/company-role-reddit-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Reddit operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Reddit values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Reddit is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Reddit is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Reddit tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Reddit is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Reddit uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-reddit-engineering-manager.json
+++ b/data/generated/modules/company-role-reddit-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Reddit operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Reddit values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Reddit is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Reddit is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Reddit tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Reddit is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Reddit uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-reddit-frontend-engineer.json
+++ b/data/generated/modules/company-role-reddit-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Reddit operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Reddit values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Reddit is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Reddit is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Reddit tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Reddit is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Reddit uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-reddit-mobile-engineer.json
+++ b/data/generated/modules/company-role-reddit-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Reddit operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Reddit values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Reddit is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Reddit is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Reddit tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Reddit is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Reddit uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-reddit-product-designer.json
+++ b/data/generated/modules/company-role-reddit-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Reddit operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Reddit values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Reddit is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Reddit is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Reddit tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Reddit is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Reddit uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-reddit-product-manager.json
+++ b/data/generated/modules/company-role-reddit-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Reddit operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Reddit values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Reddit isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Reddit tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Reddit is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Reddit uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-reddit-software-engineer.json
+++ b/data/generated/modules/company-role-reddit-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Reddit operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Reddit values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Reddit is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Reddit uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Reddit tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Reddit is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Reddit uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Reddit is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-robinhood-backend-engineer.json
+++ b/data/generated/modules/company-role-robinhood-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Robinhood operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Robinhood values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Robinhood is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Robinhood is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Robinhood tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Robinhood is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Robinhood uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-robinhood-data-scientist.json
+++ b/data/generated/modules/company-role-robinhood-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Robinhood operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Robinhood values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Robinhood is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Robinhood is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Robinhood tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Robinhood is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Robinhood uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-robinhood-engineering-manager.json
+++ b/data/generated/modules/company-role-robinhood-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Robinhood operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Robinhood values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Robinhood is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Robinhood is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Robinhood tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Robinhood is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Robinhood uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-robinhood-mobile-engineer.json
+++ b/data/generated/modules/company-role-robinhood-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Robinhood operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Robinhood values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Robinhood is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Robinhood is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Robinhood tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Robinhood is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Robinhood uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-robinhood-product-designer.json
+++ b/data/generated/modules/company-role-robinhood-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Robinhood operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Robinhood values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Robinhood is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Robinhood is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Robinhood tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Robinhood is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Robinhood uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-robinhood-product-manager.json
+++ b/data/generated/modules/company-role-robinhood-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Robinhood operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Robinhood values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Robinhood isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing withou..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Robinhood tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Robinhood is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Robinhood uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-robinhood-security-engineer.json
+++ b/data/generated/modules/company-role-robinhood-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Robinhood operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Robinhood values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Robinhood is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Robinhood is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Robinhood tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Robinhood is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Robinhood uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-robinhood-software-engineer.json
+++ b/data/generated/modules/company-role-robinhood-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Robinhood operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Robinhood values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Robinhood is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upda..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Robinhood uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questi..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Robinhood tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Robinhood is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Robinhood uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Robinhood is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-roblox-backend-engineer.json
+++ b/data/generated/modules/company-role-roblox-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Roblox operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Roblox values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Roblox is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Roblox is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Roblox tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Roblox is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Roblox values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Roblox uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Roblox is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-roblox-data-scientist.json
+++ b/data/generated/modules/company-role-roblox-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Roblox operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Roblox values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Roblox is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Roblox is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Roblox tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Roblox is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Roblox values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Roblox uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Roblox is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-roblox-engineering-manager.json
+++ b/data/generated/modules/company-role-roblox-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Roblox operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Roblox values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Roblox is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Roblox is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Roblox tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Roblox is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Roblox values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Roblox uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Roblox is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-roblox-mobile-engineer.json
+++ b/data/generated/modules/company-role-roblox-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Roblox operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Roblox values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Roblox is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Roblox is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Roblox tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Roblox is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Roblox values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Roblox uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Roblox is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-roblox-product-designer.json
+++ b/data/generated/modules/company-role-roblox-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Roblox operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Roblox values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Roblox is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Roblox is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Roblox tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Roblox is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Roblox values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Roblox uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Roblox is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-roblox-product-manager.json
+++ b/data/generated/modules/company-role-roblox-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Roblox operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Roblox values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Roblox isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Roblox is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Roblox tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Roblox is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Roblox values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Roblox uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Roblox is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-roblox-software-engineer.json
+++ b/data/generated/modules/company-role-roblox-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Roblox operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Roblox values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Roblox is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Roblox uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Roblox tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Roblox is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Roblox values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Roblox uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Roblox is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-salesforce-account-executive.json
+++ b/data/generated/modules/company-role-salesforce-account-executive.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Salesforce operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Salesforce values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Salesforce is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Salesforce is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Salesforce tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Salesforce is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Salesforce uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-salesforce-backend-engineer.json
+++ b/data/generated/modules/company-role-salesforce-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Salesforce operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Salesforce values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Salesforce is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Salesforce is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Salesforce tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Salesforce is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Salesforce uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-salesforce-data-scientist.json
+++ b/data/generated/modules/company-role-salesforce-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Salesforce operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Salesforce values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Salesforce is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Salesforce is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Salesforce tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Salesforce is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Salesforce uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-salesforce-devops-engineer.json
+++ b/data/generated/modules/company-role-salesforce-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Salesforce operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Salesforce values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Salesforce is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Salesforce is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Salesforce tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Salesforce is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Salesforce uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-salesforce-engineering-manager.json
+++ b/data/generated/modules/company-role-salesforce-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Salesforce operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Salesforce values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Salesforce is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Salesforce is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Salesforce tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Salesforce is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Salesforce uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-salesforce-frontend-engineer.json
+++ b/data/generated/modules/company-role-salesforce-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Salesforce operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Salesforce values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Salesforce is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Salesforce is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Salesforce tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Salesforce is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Salesforce uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-salesforce-product-designer.json
+++ b/data/generated/modules/company-role-salesforce-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Salesforce operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Salesforce values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Salesforce is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Salesforce is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Salesforce tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Salesforce is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Salesforce uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-salesforce-product-manager.json
+++ b/data/generated/modules/company-role-salesforce-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Salesforce operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Salesforce values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Salesforce isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing witho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I jus..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Salesforce tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Salesforce is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Salesforce uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-salesforce-sales-engineer.json
+++ b/data/generated/modules/company-role-salesforce-sales-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Salesforce operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Salesforce values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Salesforce is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Salesforce is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Salesforce tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Salesforce is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Salesforce uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-salesforce-software-engineer.json
+++ b/data/generated/modules/company-role-salesforce-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Salesforce operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Salesforce values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Salesforce is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Salesforce uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying quest..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Salesforce tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Salesforce is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Salesforce uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-salesforce-solutions-architect.json
+++ b/data/generated/modules/company-role-salesforce-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Salesforce operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Salesforce values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Salesforce is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Salesforce is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Salesforce tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Salesforce is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Salesforce uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Salesforce is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-sap-backend-engineer.json
+++ b/data/generated/modules/company-role-sap-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "SAP operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. SAP values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but SAP is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "SAP is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "SAP tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but SAP is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "SAP values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but SAP uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "SAP is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-sap-data-scientist.json
+++ b/data/generated/modules/company-role-sap-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "SAP operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. SAP values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but SAP is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "SAP is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "SAP tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but SAP is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "SAP values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but SAP uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "SAP is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-sap-engineering-manager.json
+++ b/data/generated/modules/company-role-sap-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "SAP operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. SAP values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but SAP is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "SAP is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "SAP tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but SAP is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "SAP values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but SAP uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "SAP is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-sap-product-manager.json
+++ b/data/generated/modules/company-role-sap-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "SAP operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. SAP values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but SAP isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without show..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "SAP is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tell ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "SAP tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but SAP is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "SAP values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but SAP uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "SAP is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-sap-sales-engineer.json
+++ b/data/generated/modules/company-role-sap-sales-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "SAP operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. SAP values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but SAP is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "SAP is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "SAP tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but SAP is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "SAP values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but SAP uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "SAP is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-sap-software-engineer.json
+++ b/data/generated/modules/company-role-sap-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "SAP operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. SAP values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. SAP is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? T..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but SAP uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions or..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "SAP tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but SAP is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "SAP values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but SAP uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "SAP is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-sap-solutions-architect.json
+++ b/data/generated/modules/company-role-sap-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "SAP operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. SAP values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take o..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but SAP is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ver..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "SAP is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "SAP tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but SAP is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest abo..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "SAP values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Cand..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but SAP uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? Th..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "SAP is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem befo..."
           }
         }
       ]

--- a/data/generated/modules/company-role-servicenow-backend-engineer.json
+++ b/data/generated/modules/company-role-servicenow-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "ServiceNow operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. ServiceNow values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but ServiceNow is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "ServiceNow is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "ServiceNow tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but ServiceNow is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but ServiceNow uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-servicenow-data-scientist.json
+++ b/data/generated/modules/company-role-servicenow-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "ServiceNow operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. ServiceNow values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but ServiceNow is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "ServiceNow is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "ServiceNow tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but ServiceNow is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but ServiceNow uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-servicenow-devops-engineer.json
+++ b/data/generated/modules/company-role-servicenow-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "ServiceNow operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. ServiceNow values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but ServiceNow is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "ServiceNow is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "ServiceNow tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but ServiceNow is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but ServiceNow uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-servicenow-engineering-manager.json
+++ b/data/generated/modules/company-role-servicenow-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "ServiceNow operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. ServiceNow values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but ServiceNow is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "ServiceNow is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "ServiceNow tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but ServiceNow is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but ServiceNow uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-servicenow-product-manager.json
+++ b/data/generated/modules/company-role-servicenow-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "ServiceNow operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. ServiceNow values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but ServiceNow isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing witho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I jus..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "ServiceNow tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but ServiceNow is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but ServiceNow uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-servicenow-sales-engineer.json
+++ b/data/generated/modules/company-role-servicenow-sales-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "ServiceNow operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. ServiceNow values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but ServiceNow is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "ServiceNow is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "ServiceNow tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but ServiceNow is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but ServiceNow uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-servicenow-software-engineer.json
+++ b/data/generated/modules/company-role-servicenow-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "ServiceNow operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. ServiceNow values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. ServiceNow is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upd..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but ServiceNow uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying quest..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "ServiceNow tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but ServiceNow is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but ServiceNow uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-servicenow-solutions-architect.json
+++ b/data/generated/modules/company-role-servicenow-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "ServiceNow operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. ServiceNow values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but ServiceNow is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "ServiceNow is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not l..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "ServiceNow tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but ServiceNow is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hon..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted i..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but ServiceNow uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to le..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "ServiceNow is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real probl..."
           }
         }
       ]

--- a/data/generated/modules/company-role-shopify-backend-engineer.json
+++ b/data/generated/modules/company-role-shopify-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Shopify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Shopify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Shopify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Shopify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Shopify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Shopify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Shopify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-shopify-data-engineer.json
+++ b/data/generated/modules/company-role-shopify-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Shopify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Shopify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Shopify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Shopify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Shopify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Shopify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Shopify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-shopify-data-scientist.json
+++ b/data/generated/modules/company-role-shopify-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Shopify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Shopify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Shopify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Shopify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Shopify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Shopify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Shopify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-shopify-engineering-manager.json
+++ b/data/generated/modules/company-role-shopify-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Shopify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Shopify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Shopify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Shopify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Shopify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Shopify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Shopify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-shopify-frontend-engineer.json
+++ b/data/generated/modules/company-role-shopify-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Shopify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Shopify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Shopify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Shopify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Shopify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Shopify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Shopify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-shopify-product-designer.json
+++ b/data/generated/modules/company-role-shopify-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Shopify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Shopify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Shopify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Shopify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Shopify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Shopify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Shopify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-shopify-product-manager.json
+++ b/data/generated/modules/company-role-shopify-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Shopify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Shopify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Shopify isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just t..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Shopify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Shopify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Shopify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-shopify-software-engineer.json
+++ b/data/generated/modules/company-role-shopify-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Shopify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Shopify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Shopify is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key update..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Shopify uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying question..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Shopify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Shopify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Shopify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-shopify-ux-researcher.json
+++ b/data/generated/modules/company-role-shopify-ux-researcher.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Shopify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Shopify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Shopify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Shopify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Shopify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Shopify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Shopify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Shopify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-slack-backend-engineer.json
+++ b/data/generated/modules/company-role-slack-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Slack operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Slack values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Slack is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Slack is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Slack tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Slack is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Slack values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Slack uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Slack is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-slack-engineering-manager.json
+++ b/data/generated/modules/company-role-slack-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Slack operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Slack values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Slack is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Slack is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Slack tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Slack is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Slack values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Slack uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Slack is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-slack-frontend-engineer.json
+++ b/data/generated/modules/company-role-slack-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Slack operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Slack values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Slack is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Slack is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Slack tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Slack is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Slack values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Slack uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Slack is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-slack-product-designer.json
+++ b/data/generated/modules/company-role-slack-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Slack operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Slack values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Slack is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Slack is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Slack tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Slack is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Slack values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Slack uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Slack is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-slack-product-manager.json
+++ b/data/generated/modules/company-role-slack-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Slack operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Slack values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Slack isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sh..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Slack is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tel..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Slack tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Slack is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Slack values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Slack uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Slack is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-slack-software-engineer.json
+++ b/data/generated/modules/company-role-slack-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Slack operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Slack values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Slack is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates?..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Slack uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Slack tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Slack is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Slack values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Slack uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Slack is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-slack-ux-researcher.json
+++ b/data/generated/modules/company-role-slack-ux-researcher.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Slack operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Slack values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Slack is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Slack is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Slack tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Slack is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Slack values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Slack uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Slack is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snap-backend-engineer.json
+++ b/data/generated/modules/company-role-snap-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snap operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snap values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Snap is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Snap is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snap tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snap is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snap uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snap-data-scientist.json
+++ b/data/generated/modules/company-role-snap-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snap operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snap values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Snap is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Snap is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snap tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snap is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snap uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snap-engineering-manager.json
+++ b/data/generated/modules/company-role-snap-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snap operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snap values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Snap is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Snap is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snap tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snap is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snap uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snap-frontend-engineer.json
+++ b/data/generated/modules/company-role-snap-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snap operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snap values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Snap is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Snap is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snap tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snap is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snap uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snap-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-snap-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snap operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snap values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Snap is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Snap is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snap tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snap is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snap uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snap-mobile-engineer.json
+++ b/data/generated/modules/company-role-snap-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snap operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snap values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Snap is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Snap is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snap tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snap is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snap uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snap-product-designer.json
+++ b/data/generated/modules/company-role-snap-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snap operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snap values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Snap is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Snap is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snap tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snap is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snap uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snap-product-manager.json
+++ b/data/generated/modules/company-role-snap-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snap operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snap values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Snap isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tell..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snap tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snap is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snap uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snap-software-engineer.json
+++ b/data/generated/modules/company-role-snap-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snap operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snap values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Snap is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Snap uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions o..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snap tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snap is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snap uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snap is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snowflake-backend-engineer.json
+++ b/data/generated/modules/company-role-snowflake-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snowflake operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snowflake values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Snowflake is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Snowflake is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snowflake tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snowflake is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snowflake uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snowflake-data-engineer.json
+++ b/data/generated/modules/company-role-snowflake-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snowflake operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snowflake values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Snowflake is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Snowflake is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snowflake tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snowflake is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snowflake uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snowflake-data-scientist.json
+++ b/data/generated/modules/company-role-snowflake-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snowflake operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snowflake values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Snowflake is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Snowflake is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snowflake tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snowflake is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snowflake uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snowflake-devops-engineer.json
+++ b/data/generated/modules/company-role-snowflake-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snowflake operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snowflake values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Snowflake is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Snowflake is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snowflake tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snowflake is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snowflake uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snowflake-engineering-manager.json
+++ b/data/generated/modules/company-role-snowflake-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snowflake operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snowflake values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Snowflake is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Snowflake is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snowflake tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snowflake is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snowflake uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snowflake-product-manager.json
+++ b/data/generated/modules/company-role-snowflake-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snowflake operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snowflake values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Snowflake isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing withou..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snowflake tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snowflake is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snowflake uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snowflake-sales-engineer.json
+++ b/data/generated/modules/company-role-snowflake-sales-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snowflake operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snowflake values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Snowflake is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Snowflake is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snowflake tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snowflake is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snowflake uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snowflake-software-engineer.json
+++ b/data/generated/modules/company-role-snowflake-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snowflake operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snowflake values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Snowflake is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upda..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Snowflake uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questi..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snowflake tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snowflake is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snowflake uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-snowflake-solutions-architect.json
+++ b/data/generated/modules/company-role-snowflake-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Snowflake operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Snowflake values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Snowflake is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Snowflake is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Snowflake tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Snowflake is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Snowflake uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Snowflake is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-splunk-backend-engineer.json
+++ b/data/generated/modules/company-role-splunk-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Splunk operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Splunk values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Splunk is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Splunk is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Splunk tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Splunk is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Splunk uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-splunk-data-scientist.json
+++ b/data/generated/modules/company-role-splunk-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Splunk operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Splunk values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Splunk is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Splunk is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Splunk tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Splunk is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Splunk uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-splunk-devops-engineer.json
+++ b/data/generated/modules/company-role-splunk-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Splunk operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Splunk values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Splunk is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Splunk is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Splunk tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Splunk is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Splunk uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-splunk-engineering-manager.json
+++ b/data/generated/modules/company-role-splunk-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Splunk operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Splunk values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Splunk is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Splunk is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Splunk tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Splunk is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Splunk uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-splunk-product-manager.json
+++ b/data/generated/modules/company-role-splunk-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Splunk operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Splunk values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Splunk isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Splunk tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Splunk is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Splunk uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-splunk-sales-engineer.json
+++ b/data/generated/modules/company-role-splunk-sales-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Splunk operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Splunk values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Splunk is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Splunk is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Splunk tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Splunk is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Splunk uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-splunk-software-engineer.json
+++ b/data/generated/modules/company-role-splunk-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Splunk operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Splunk values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Splunk is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Splunk uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Splunk tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Splunk is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Splunk uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-splunk-solutions-architect.json
+++ b/data/generated/modules/company-role-splunk-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Splunk operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Splunk values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Splunk is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Splunk is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Splunk tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Splunk is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Splunk uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Splunk is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-spotify-backend-engineer.json
+++ b/data/generated/modules/company-role-spotify-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Spotify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Spotify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Spotify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Spotify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Spotify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Spotify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Spotify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-spotify-data-engineer.json
+++ b/data/generated/modules/company-role-spotify-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Spotify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Spotify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Spotify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Spotify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Spotify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Spotify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Spotify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-spotify-data-scientist.json
+++ b/data/generated/modules/company-role-spotify-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Spotify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Spotify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Spotify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Spotify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Spotify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Spotify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Spotify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-spotify-engineering-manager.json
+++ b/data/generated/modules/company-role-spotify-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Spotify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Spotify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Spotify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Spotify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Spotify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Spotify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Spotify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-spotify-frontend-engineer.json
+++ b/data/generated/modules/company-role-spotify-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Spotify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Spotify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Spotify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Spotify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Spotify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Spotify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Spotify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-spotify-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-spotify-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Spotify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Spotify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Spotify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Spotify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Spotify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Spotify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Spotify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-spotify-mobile-engineer.json
+++ b/data/generated/modules/company-role-spotify-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Spotify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Spotify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Spotify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Spotify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Spotify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Spotify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Spotify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-spotify-product-designer.json
+++ b/data/generated/modules/company-role-spotify-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Spotify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Spotify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Spotify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Spotify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Spotify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Spotify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Spotify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-spotify-product-manager.json
+++ b/data/generated/modules/company-role-spotify-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Spotify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Spotify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Spotify isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just t..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Spotify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Spotify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Spotify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-spotify-software-engineer.json
+++ b/data/generated/modules/company-role-spotify-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Spotify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Spotify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Spotify is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key update..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Spotify uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying question..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Spotify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Spotify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Spotify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-spotify-ux-researcher.json
+++ b/data/generated/modules/company-role-spotify-ux-researcher.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Spotify operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Spotify values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Spotify is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Spotify is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Spotify tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Spotify is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Spotify uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Spotify is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-stripe-backend-engineer.json
+++ b/data/generated/modules/company-role-stripe-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Stripe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Stripe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Stripe is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Stripe is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Stripe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Stripe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Stripe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-stripe-data-engineer.json
+++ b/data/generated/modules/company-role-stripe-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Stripe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Stripe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Stripe is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Stripe is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Stripe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Stripe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Stripe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-stripe-data-scientist.json
+++ b/data/generated/modules/company-role-stripe-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Stripe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Stripe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Stripe is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Stripe is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Stripe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Stripe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Stripe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-stripe-devops-engineer.json
+++ b/data/generated/modules/company-role-stripe-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Stripe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Stripe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Stripe is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Stripe is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Stripe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Stripe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Stripe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-stripe-engineering-manager.json
+++ b/data/generated/modules/company-role-stripe-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Stripe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Stripe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Stripe is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Stripe is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Stripe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Stripe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Stripe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-stripe-frontend-engineer.json
+++ b/data/generated/modules/company-role-stripe-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Stripe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Stripe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Stripe is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Stripe is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Stripe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Stripe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Stripe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-stripe-product-designer.json
+++ b/data/generated/modules/company-role-stripe-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Stripe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Stripe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Stripe is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Stripe is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Stripe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Stripe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Stripe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-stripe-product-manager.json
+++ b/data/generated/modules/company-role-stripe-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Stripe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Stripe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Stripe isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Stripe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Stripe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Stripe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-stripe-security-engineer.json
+++ b/data/generated/modules/company-role-stripe-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Stripe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Stripe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Stripe is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Stripe is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Stripe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Stripe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Stripe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-stripe-software-engineer.json
+++ b/data/generated/modules/company-role-stripe-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Stripe operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Stripe values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Stripe is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Stripe uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Stripe tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Stripe is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Stripe uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Stripe is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-target-backend-engineer.json
+++ b/data/generated/modules/company-role-target-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Target operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Target values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Target is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Target is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Target tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Target is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Target values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Target uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Target is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-target-business-analyst.json
+++ b/data/generated/modules/company-role-target-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Target operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Target values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Target is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Target is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Target tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Target is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Target values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Target uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Target is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-target-data-engineer.json
+++ b/data/generated/modules/company-role-target-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Target operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Target values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Target is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Target is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Target tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Target is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Target values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Target uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Target is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-target-data-scientist.json
+++ b/data/generated/modules/company-role-target-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Target operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Target values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Target is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Target is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Target tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Target is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Target values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Target uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Target is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-target-engineering-manager.json
+++ b/data/generated/modules/company-role-target-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Target operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Target values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Target is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Target is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Target tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Target is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Target values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Target uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Target is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-target-product-manager.json
+++ b/data/generated/modules/company-role-target-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Target operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Target values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Target isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Target is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Target tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Target is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Target values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Target uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Target is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-target-software-engineer.json
+++ b/data/generated/modules/company-role-target-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Target operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Target values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Target is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Target uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Target tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Target is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Target values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Target uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Target is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tesla-backend-engineer.json
+++ b/data/generated/modules/company-role-tesla-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Tesla operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Tesla values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Tesla is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Tesla is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Tesla tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Tesla is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Tesla uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tesla-data-engineer.json
+++ b/data/generated/modules/company-role-tesla-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Tesla operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Tesla values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Tesla is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Tesla is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Tesla tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Tesla is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Tesla uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tesla-data-scientist.json
+++ b/data/generated/modules/company-role-tesla-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Tesla operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Tesla values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Tesla is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Tesla is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Tesla tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Tesla is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Tesla uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tesla-devops-engineer.json
+++ b/data/generated/modules/company-role-tesla-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Tesla operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Tesla values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Tesla is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Tesla is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Tesla tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Tesla is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Tesla uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tesla-engineering-manager.json
+++ b/data/generated/modules/company-role-tesla-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Tesla operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Tesla values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Tesla is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Tesla is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Tesla tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Tesla is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Tesla uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tesla-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-tesla-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Tesla operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Tesla values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Tesla is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Tesla is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Tesla tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Tesla is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Tesla uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tesla-mobile-engineer.json
+++ b/data/generated/modules/company-role-tesla-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Tesla operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Tesla values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Tesla is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Tesla is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Tesla tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Tesla is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Tesla uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tesla-product-manager.json
+++ b/data/generated/modules/company-role-tesla-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Tesla operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Tesla values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Tesla isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sh..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tel..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Tesla tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Tesla is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Tesla uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tesla-security-engineer.json
+++ b/data/generated/modules/company-role-tesla-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Tesla operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Tesla values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Tesla is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to v..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Tesla is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Tesla tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Tesla is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Tesla uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tesla-software-engineer.json
+++ b/data/generated/modules/company-role-tesla-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Tesla operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: d..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Tesla values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Tesla is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates?..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Tesla uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Tesla tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer A..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Tesla is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest a..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Ca..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Tesla uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Tesla is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem be..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tiktok-backend-engineer.json
+++ b/data/generated/modules/company-role-tiktok-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "TikTok operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. TikTok values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but TikTok is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "TikTok is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "TikTok tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but TikTok is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but TikTok uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tiktok-data-scientist.json
+++ b/data/generated/modules/company-role-tiktok-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "TikTok operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. TikTok values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but TikTok is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "TikTok is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "TikTok tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but TikTok is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but TikTok uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tiktok-engineering-manager.json
+++ b/data/generated/modules/company-role-tiktok-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "TikTok operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. TikTok values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but TikTok is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "TikTok is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "TikTok tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but TikTok is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but TikTok uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tiktok-frontend-engineer.json
+++ b/data/generated/modules/company-role-tiktok-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "TikTok operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. TikTok values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but TikTok is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "TikTok is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "TikTok tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but TikTok is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but TikTok uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tiktok-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-tiktok-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "TikTok operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. TikTok values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but TikTok is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "TikTok is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "TikTok tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but TikTok is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but TikTok uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tiktok-mobile-engineer.json
+++ b/data/generated/modules/company-role-tiktok-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "TikTok operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. TikTok values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but TikTok is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "TikTok is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "TikTok tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but TikTok is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but TikTok uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tiktok-product-designer.json
+++ b/data/generated/modules/company-role-tiktok-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "TikTok operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. TikTok values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but TikTok is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "TikTok is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "TikTok tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but TikTok is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but TikTok uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tiktok-product-manager.json
+++ b/data/generated/modules/company-role-tiktok-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "TikTok operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. TikTok values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but TikTok isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "TikTok tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but TikTok is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but TikTok uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-tiktok-software-engineer.json
+++ b/data/generated/modules/company-role-tiktok-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "TikTok operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. TikTok values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. TikTok is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but TikTok uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "TikTok tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but TikTok is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but TikTok uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "TikTok is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-twilio-backend-engineer.json
+++ b/data/generated/modules/company-role-twilio-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Twilio operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Twilio values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Twilio is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Twilio is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Twilio tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Twilio is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Twilio values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Twilio uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Twilio is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-twilio-devops-engineer.json
+++ b/data/generated/modules/company-role-twilio-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Twilio operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Twilio values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Twilio is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Twilio is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Twilio tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Twilio is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Twilio values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Twilio uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Twilio is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-twilio-engineering-manager.json
+++ b/data/generated/modules/company-role-twilio-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Twilio operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Twilio values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Twilio is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Twilio is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Twilio tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Twilio is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Twilio values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Twilio uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Twilio is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-twilio-product-designer.json
+++ b/data/generated/modules/company-role-twilio-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Twilio operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Twilio values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Twilio is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Twilio is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Twilio tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Twilio is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Twilio values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Twilio uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Twilio is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-twilio-product-manager.json
+++ b/data/generated/modules/company-role-twilio-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Twilio operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Twilio values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Twilio isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Twilio is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Twilio tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Twilio is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Twilio values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Twilio uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Twilio is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-twilio-software-engineer.json
+++ b/data/generated/modules/company-role-twilio-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Twilio operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Twilio values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Twilio is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Twilio uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Twilio tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Twilio is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Twilio values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Twilio uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Twilio is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-twilio-solutions-architect.json
+++ b/data/generated/modules/company-role-twilio-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Twilio operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Twilio values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Twilio is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Twilio is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Twilio tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Twilio is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Twilio values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Twilio uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Twilio is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-two-sigma-backend-engineer.json
+++ b/data/generated/modules/company-role-two-sigma-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Two Sigma operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Two Sigma values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Two Sigma is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Two Sigma is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Two Sigma tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Two Sigma is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Two Sigma values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Two Sigma uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Two Sigma is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-two-sigma-data-engineer.json
+++ b/data/generated/modules/company-role-two-sigma-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Two Sigma operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Two Sigma values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Two Sigma is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Two Sigma is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Two Sigma tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Two Sigma is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Two Sigma values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Two Sigma uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Two Sigma is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-two-sigma-data-scientist.json
+++ b/data/generated/modules/company-role-two-sigma-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Two Sigma operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Two Sigma values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Two Sigma is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Two Sigma is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Two Sigma tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Two Sigma is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Two Sigma values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Two Sigma uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Two Sigma is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-two-sigma-financial-analyst.json
+++ b/data/generated/modules/company-role-two-sigma-financial-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Two Sigma operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Two Sigma values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Two Sigma is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Two Sigma is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Two Sigma tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Two Sigma is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Two Sigma values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Two Sigma uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Two Sigma is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-two-sigma-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-two-sigma-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Two Sigma operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Two Sigma values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Two Sigma is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Two Sigma is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not li..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Two Sigma tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Two Sigma is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Two Sigma values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Two Sigma uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Two Sigma is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-two-sigma-software-engineer.json
+++ b/data/generated/modules/company-role-two-sigma-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Two Sigma operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question i..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Two Sigma values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Two Sigma is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key upda..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Two Sigma uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questi..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Two Sigma tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the custom..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Two Sigma is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be hone..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Two Sigma values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Two Sigma uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to lea..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Two Sigma is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real proble..."
           }
         }
       ]

--- a/data/generated/modules/company-role-uber-backend-engineer.json
+++ b/data/generated/modules/company-role-uber-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Uber operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Uber values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Uber is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Uber is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Uber tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Uber is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Uber uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-uber-data-engineer.json
+++ b/data/generated/modules/company-role-uber-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Uber operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Uber values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Uber is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Uber is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Uber tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Uber is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Uber uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-uber-data-scientist.json
+++ b/data/generated/modules/company-role-uber-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Uber operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Uber values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Uber is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Uber is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Uber tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Uber is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Uber uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-uber-devops-engineer.json
+++ b/data/generated/modules/company-role-uber-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Uber operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Uber values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Uber is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Uber is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Uber tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Uber is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Uber uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-uber-engineering-manager.json
+++ b/data/generated/modules/company-role-uber-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Uber operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Uber values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Uber is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Uber is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Uber tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Uber is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Uber uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-uber-machine-learning-engineer.json
+++ b/data/generated/modules/company-role-uber-machine-learning-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Uber operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Uber values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Uber is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Uber is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Uber tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Uber is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Uber uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-uber-mobile-engineer.json
+++ b/data/generated/modules/company-role-uber-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Uber operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Uber values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Uber is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Uber is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Uber tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Uber is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Uber uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-uber-product-designer.json
+++ b/data/generated/modules/company-role-uber-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Uber operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Uber values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Uber is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Uber is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Uber tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Uber is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Uber uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-uber-product-manager.json
+++ b/data/generated/modules/company-role-uber-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Uber operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Uber values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Uber isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tell..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Uber tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Uber is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Uber uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-uber-software-engineer.json
+++ b/data/generated/modules/company-role-uber-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Uber operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Uber values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Uber is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Uber uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions o..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Uber tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Uber is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Uber uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Uber is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-unitedhealth-backend-engineer.json
+++ b/data/generated/modules/company-role-unitedhealth-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "UnitedHealth Group operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-q..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. UnitedHealth Group values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but UnitedHealth Group is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when the..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "UnitedHealth Group is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterativ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "UnitedHealth Group tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but UnitedHealth Group is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "UnitedHealth Group values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or re..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but UnitedHealth Group uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wa..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "UnitedHealth Group is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the re..."
           }
         }
       ]

--- a/data/generated/modules/company-role-unitedhealth-business-analyst.json
+++ b/data/generated/modules/company-role-unitedhealth-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "UnitedHealth Group operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-q..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. UnitedHealth Group values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but UnitedHealth Group is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when the..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "UnitedHealth Group is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterativ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "UnitedHealth Group tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but UnitedHealth Group is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "UnitedHealth Group values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or re..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but UnitedHealth Group uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wa..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "UnitedHealth Group is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the re..."
           }
         }
       ]

--- a/data/generated/modules/company-role-unitedhealth-data-engineer.json
+++ b/data/generated/modules/company-role-unitedhealth-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "UnitedHealth Group operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-q..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. UnitedHealth Group values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but UnitedHealth Group is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when the..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "UnitedHealth Group is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterativ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "UnitedHealth Group tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but UnitedHealth Group is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "UnitedHealth Group values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or re..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but UnitedHealth Group uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wa..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "UnitedHealth Group is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the re..."
           }
         }
       ]

--- a/data/generated/modules/company-role-unitedhealth-data-scientist.json
+++ b/data/generated/modules/company-role-unitedhealth-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "UnitedHealth Group operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-q..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. UnitedHealth Group values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but UnitedHealth Group is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when the..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "UnitedHealth Group is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterativ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "UnitedHealth Group tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but UnitedHealth Group is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "UnitedHealth Group values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or re..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but UnitedHealth Group uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wa..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "UnitedHealth Group is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the re..."
           }
         }
       ]

--- a/data/generated/modules/company-role-unitedhealth-engineering-manager.json
+++ b/data/generated/modules/company-role-unitedhealth-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "UnitedHealth Group operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-q..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. UnitedHealth Group values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but UnitedHealth Group is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when the..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "UnitedHealth Group is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterativ..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "UnitedHealth Group tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but UnitedHealth Group is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "UnitedHealth Group values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or re..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but UnitedHealth Group uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wa..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "UnitedHealth Group is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the re..."
           }
         }
       ]

--- a/data/generated/modules/company-role-unitedhealth-product-manager.json
+++ b/data/generated/modules/company-role-unitedhealth-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "UnitedHealth Group operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-q..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. UnitedHealth Group values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but UnitedHealth Group isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessi..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "UnitedHealth Group is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is eithe..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "UnitedHealth Group tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but UnitedHealth Group is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "UnitedHealth Group values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or re..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but UnitedHealth Group uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wa..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "UnitedHealth Group is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the re..."
           }
         }
       ]

--- a/data/generated/modules/company-role-unitedhealth-software-engineer.json
+++ b/data/generated/modules/company-role-unitedhealth-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "UnitedHealth Group operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-q..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. UnitedHealth Group values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. UnitedHealth Group is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but UnitedHealth Group uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifyi..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "UnitedHealth Group tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but UnitedHealth Group is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better t..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "UnitedHealth Group values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or re..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but UnitedHealth Group uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd wa..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "UnitedHealth Group is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the re..."
           }
         }
       ]

--- a/data/generated/modules/company-role-vercel-backend-engineer.json
+++ b/data/generated/modules/company-role-vercel-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Vercel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Vercel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Vercel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Vercel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Vercel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Vercel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Vercel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Vercel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Vercel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-vercel-devops-engineer.json
+++ b/data/generated/modules/company-role-vercel-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Vercel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Vercel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Vercel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Vercel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Vercel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Vercel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Vercel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Vercel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Vercel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-vercel-engineering-manager.json
+++ b/data/generated/modules/company-role-vercel-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Vercel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Vercel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Vercel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Vercel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Vercel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Vercel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Vercel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Vercel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Vercel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-vercel-frontend-engineer.json
+++ b/data/generated/modules/company-role-vercel-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Vercel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Vercel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Vercel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Vercel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Vercel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Vercel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Vercel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Vercel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Vercel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-vercel-product-designer.json
+++ b/data/generated/modules/company-role-vercel-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Vercel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Vercel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Vercel is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Vercel is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Vercel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Vercel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Vercel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Vercel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Vercel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-vercel-product-manager.json
+++ b/data/generated/modules/company-role-vercel-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Vercel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Vercel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Vercel isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Vercel is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Vercel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Vercel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Vercel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Vercel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Vercel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-vercel-software-engineer.json
+++ b/data/generated/modules/company-role-vercel-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Vercel operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Vercel values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Vercel is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Vercel uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Vercel tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Vercel is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Vercel values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Vercel uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Vercel is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-visa-backend-engineer.json
+++ b/data/generated/modules/company-role-visa-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Visa operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Visa values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Visa is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Visa is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Visa tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Visa is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Visa values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Visa uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Visa is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-visa-data-engineer.json
+++ b/data/generated/modules/company-role-visa-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Visa operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Visa values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Visa is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Visa is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Visa tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Visa is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Visa values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Visa uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Visa is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-visa-data-scientist.json
+++ b/data/generated/modules/company-role-visa-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Visa operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Visa values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Visa is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Visa is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Visa tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Visa is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Visa values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Visa uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Visa is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-visa-engineering-manager.json
+++ b/data/generated/modules/company-role-visa-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Visa operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Visa values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Visa is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Visa is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Visa tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Visa is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Visa values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Visa uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Visa is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-visa-product-manager.json
+++ b/data/generated/modules/company-role-visa-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Visa operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Visa values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Visa isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Visa is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tell..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Visa tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Visa is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Visa values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Visa uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Visa is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-visa-security-engineer.json
+++ b/data/generated/modules/company-role-visa-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Visa operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Visa values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Visa is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Visa is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Visa tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Visa is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Visa values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Visa uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Visa is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-visa-software-engineer.json
+++ b/data/generated/modules/company-role-visa-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Visa operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Visa values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Visa is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Visa uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions o..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Visa tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Visa is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Visa values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Visa uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Visa is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-vmware-backend-engineer.json
+++ b/data/generated/modules/company-role-vmware-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "VMware operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. VMware values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but VMware is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "VMware is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "VMware tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but VMware is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "VMware values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but VMware uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "VMware is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-vmware-devops-engineer.json
+++ b/data/generated/modules/company-role-vmware-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "VMware operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. VMware values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but VMware is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "VMware is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "VMware tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but VMware is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "VMware values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but VMware uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "VMware is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-vmware-engineering-manager.json
+++ b/data/generated/modules/company-role-vmware-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "VMware operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. VMware values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but VMware is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "VMware is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "VMware tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but VMware is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "VMware values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but VMware uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "VMware is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-vmware-product-manager.json
+++ b/data/generated/modules/company-role-vmware-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "VMware operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. VMware values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but VMware isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without s..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "VMware is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just te..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "VMware tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but VMware is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "VMware values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but VMware uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "VMware is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-vmware-software-engineer.json
+++ b/data/generated/modules/company-role-vmware-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "VMware operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. VMware values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. VMware is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but VMware uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "VMware tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but VMware is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "VMware values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but VMware uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "VMware is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-vmware-solutions-architect.json
+++ b/data/generated/modules/company-role-vmware-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "VMware operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. VMware values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you tak..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but VMware is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "VMware is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "VMware tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but VMware is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "VMware values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. C..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but VMware uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn?..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "VMware is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem b..."
           }
         }
       ]

--- a/data/generated/modules/company-role-walmart-backend-engineer.json
+++ b/data/generated/modules/company-role-walmart-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Walmart operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Walmart values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Walmart is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Walmart is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Walmart tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Walmart is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Walmart values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Walmart uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Walmart is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-walmart-business-analyst.json
+++ b/data/generated/modules/company-role-walmart-business-analyst.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Walmart operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Walmart values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Walmart is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Walmart is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Walmart tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Walmart is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Walmart values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Walmart uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Walmart is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-walmart-data-engineer.json
+++ b/data/generated/modules/company-role-walmart-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Walmart operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Walmart values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Walmart is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Walmart is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Walmart tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Walmart is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Walmart values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Walmart uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Walmart is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-walmart-data-scientist.json
+++ b/data/generated/modules/company-role-walmart-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Walmart operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Walmart values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Walmart is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Walmart is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Walmart tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Walmart is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Walmart values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Walmart uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Walmart is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-walmart-engineering-manager.json
+++ b/data/generated/modules/company-role-walmart-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Walmart operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Walmart values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Walmart is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Walmart is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Walmart tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Walmart is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Walmart values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Walmart uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Walmart is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-walmart-product-manager.json
+++ b/data/generated/modules/company-role-walmart-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Walmart operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Walmart values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Walmart isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Walmart is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just t..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Walmart tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Walmart is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Walmart values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Walmart uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Walmart is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-walmart-software-engineer.json
+++ b/data/generated/modules/company-role-walmart-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Walmart operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Walmart values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Walmart is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key update..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Walmart uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying question..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Walmart tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Walmart is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Walmart values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Walmart uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Walmart is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-wayfair-backend-engineer.json
+++ b/data/generated/modules/company-role-wayfair-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Wayfair operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Wayfair values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Wayfair is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Wayfair is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Wayfair tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Wayfair is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Wayfair uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-wayfair-data-engineer.json
+++ b/data/generated/modules/company-role-wayfair-data-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Wayfair operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Wayfair values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Wayfair is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Wayfair is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Wayfair tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Wayfair is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Wayfair uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-wayfair-data-scientist.json
+++ b/data/generated/modules/company-role-wayfair-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Wayfair operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Wayfair values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Wayfair is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Wayfair is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Wayfair tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Wayfair is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Wayfair uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-wayfair-engineering-manager.json
+++ b/data/generated/modules/company-role-wayfair-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Wayfair operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Wayfair values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Wayfair is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Wayfair is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Wayfair tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Wayfair is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Wayfair uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-wayfair-frontend-engineer.json
+++ b/data/generated/modules/company-role-wayfair-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Wayfair operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Wayfair values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Wayfair is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Wayfair is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Wayfair tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Wayfair is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Wayfair uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-wayfair-product-designer.json
+++ b/data/generated/modules/company-role-wayfair-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Wayfair operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Wayfair values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Wayfair is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Wayfair is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Wayfair tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Wayfair is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Wayfair uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-wayfair-product-manager.json
+++ b/data/generated/modules/company-role-wayfair-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Wayfair operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Wayfair values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Wayfair isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just t..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Wayfair tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Wayfair is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Wayfair uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-wayfair-software-engineer.json
+++ b/data/generated/modules/company-role-wayfair-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Wayfair operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Wayfair values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Wayfair is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key update..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Wayfair uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying question..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Wayfair tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Wayfair is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Wayfair uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Wayfair is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-wbd-backend-engineer.json
+++ b/data/generated/modules/company-role-wbd-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Warner Bros Discovery operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The met..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Warner Bros Discovery values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behav..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Warner Bros Discovery is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Warner Bros Discovery is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is itera..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Warner Bros Discovery tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serv..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Warner Bros Discovery is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's bette..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Warner Bros Discovery values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Warner Bros Discovery uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Warner Bros Discovery is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the..."
           }
         }
       ]

--- a/data/generated/modules/company-role-wbd-data-scientist.json
+++ b/data/generated/modules/company-role-wbd-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Warner Bros Discovery operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The met..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Warner Bros Discovery values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behav..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Warner Bros Discovery is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Warner Bros Discovery is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is itera..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Warner Bros Discovery tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serv..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Warner Bros Discovery is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's bette..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Warner Bros Discovery values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Warner Bros Discovery uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Warner Bros Discovery is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the..."
           }
         }
       ]

--- a/data/generated/modules/company-role-wbd-engineering-manager.json
+++ b/data/generated/modules/company-role-wbd-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Warner Bros Discovery operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The met..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Warner Bros Discovery values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behav..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Warner Bros Discovery is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Warner Bros Discovery is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is itera..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Warner Bros Discovery tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serv..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Warner Bros Discovery is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's bette..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Warner Bros Discovery values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Warner Bros Discovery uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Warner Bros Discovery is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the..."
           }
         }
       ]

--- a/data/generated/modules/company-role-wbd-frontend-engineer.json
+++ b/data/generated/modules/company-role-wbd-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Warner Bros Discovery operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The met..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Warner Bros Discovery values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behav..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Warner Bros Discovery is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Warner Bros Discovery is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is itera..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Warner Bros Discovery tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serv..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Warner Bros Discovery is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's bette..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Warner Bros Discovery values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Warner Bros Discovery uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Warner Bros Discovery is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the..."
           }
         }
       ]

--- a/data/generated/modules/company-role-wbd-product-designer.json
+++ b/data/generated/modules/company-role-wbd-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Warner Bros Discovery operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The met..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Warner Bros Discovery values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behav..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Warner Bros Discovery is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Warner Bros Discovery is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is itera..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Warner Bros Discovery tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serv..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Warner Bros Discovery is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's bette..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Warner Bros Discovery values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Warner Bros Discovery uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Warner Bros Discovery is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the..."
           }
         }
       ]

--- a/data/generated/modules/company-role-wbd-product-manager.json
+++ b/data/generated/modules/company-role-wbd-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Warner Bros Discovery operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The met..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Warner Bros Discovery values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behav..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Warner Bros Discovery isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random gue..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Warner Bros Discovery is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is ei..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Warner Bros Discovery tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serv..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Warner Bros Discovery is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's bette..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Warner Bros Discovery values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Warner Bros Discovery uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Warner Bros Discovery is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the..."
           }
         }
       ]

--- a/data/generated/modules/company-role-wbd-software-engineer.json
+++ b/data/generated/modules/company-role-wbd-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Warner Bros Discovery operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The met..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Warner Bros Discovery values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behav..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Warner Bros Discovery is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Warner Bros Discovery uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clari..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Warner Bros Discovery tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serv..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Warner Bros Discovery is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's bette..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Warner Bros Discovery values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Warner Bros Discovery uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Warner Bros Discovery is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the..."
           }
         }
       ]

--- a/data/generated/modules/company-role-workday-backend-engineer.json
+++ b/data/generated/modules/company-role-workday-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Workday operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Workday values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Workday is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Workday is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Workday tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Workday is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Workday values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Workday uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Workday is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-workday-data-scientist.json
+++ b/data/generated/modules/company-role-workday-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Workday operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Workday values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Workday is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Workday is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Workday tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Workday is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Workday values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Workday uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Workday is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-workday-engineering-manager.json
+++ b/data/generated/modules/company-role-workday-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Workday operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Workday values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Workday is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Workday is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Workday tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Workday is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Workday values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Workday uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Workday is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-workday-product-designer.json
+++ b/data/generated/modules/company-role-workday-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Workday operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Workday values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Workday is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Workday is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Workday tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Workday is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Workday values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Workday uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Workday is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-workday-product-manager.json
+++ b/data/generated/modules/company-role-workday-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Workday operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Workday values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Workday isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Workday is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just t..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Workday tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Workday is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Workday values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Workday uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Workday is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-workday-software-engineer.json
+++ b/data/generated/modules/company-role-workday-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Workday operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Workday values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Workday is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key update..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Workday uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying question..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Workday tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Workday is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Workday values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Workday uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Workday is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-workday-solutions-architect.json
+++ b/data/generated/modules/company-role-workday-solutions-architect.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Workday operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Workday values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Workday is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Workday is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Workday tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Workday is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Workday values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Workday uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Workday is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-x-backend-engineer.json
+++ b/data/generated/modules/company-role-x-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "X operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do yo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. X values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take own..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but X is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to verif..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "X is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "X tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but X is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest about..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Candid..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but X uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? The ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem before..."
           }
         }
       ]

--- a/data/generated/modules/company-role-x-data-scientist.json
+++ b/data/generated/modules/company-role-x-data-scientist.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "X operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do yo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. X values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take own..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but X is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to verif..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "X is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "X tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but X is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest about..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Candid..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but X uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? The ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem before..."
           }
         }
       ]

--- a/data/generated/modules/company-role-x-engineering-manager.json
+++ b/data/generated/modules/company-role-x-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "X operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do yo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. X values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take own..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but X is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to verif..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "X is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "X tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but X is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest about..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Candid..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but X uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? The ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem before..."
           }
         }
       ]

--- a/data/generated/modules/company-role-x-frontend-engineer.json
+++ b/data/generated/modules/company-role-x-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "X operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do yo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. X values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take own..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but X is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to verif..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "X is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "X tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but X is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest about..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Candid..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but X uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? The ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem before..."
           }
         }
       ]

--- a/data/generated/modules/company-role-x-mobile-engineer.json
+++ b/data/generated/modules/company-role-x-mobile-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "X operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do yo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. X values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take own..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but X is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to verif..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "X is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "X tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but X is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest about..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Candid..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but X uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? The ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem before..."
           }
         }
       ]

--- a/data/generated/modules/company-role-x-product-designer.json
+++ b/data/generated/modules/company-role-x-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "X operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do yo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. X values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take own..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but X is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to verif..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "X is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "X tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but X is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest about..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Candid..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but X uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? The ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem before..."
           }
         }
       ]

--- a/data/generated/modules/company-role-x-product-manager.json
+++ b/data/generated/modules/company-role-x-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "X operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do yo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. X values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take own..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but X isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without showin..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tell th..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "X tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but X is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest about..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Candid..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but X uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? The ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem before..."
           }
         }
       ]

--- a/data/generated/modules/company-role-x-software-engineer.json
+++ b/data/generated/modules/company-role-x-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "X operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do yo..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. X values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take own..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. X is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? The..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but X uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions or a..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "X tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AND t..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but X is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest about..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Candid..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but X uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? The ..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "X is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem before..."
           }
         }
       ]

--- a/data/generated/modules/company-role-zendesk-backend-engineer.json
+++ b/data/generated/modules/company-role-zendesk-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Zendesk operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Zendesk values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Zendesk is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Zendesk is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Zendesk tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Zendesk is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zendesk values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Zendesk uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zendesk is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-zendesk-engineering-manager.json
+++ b/data/generated/modules/company-role-zendesk-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Zendesk operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Zendesk values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Zendesk is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Zendesk is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Zendesk tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Zendesk is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zendesk values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Zendesk uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zendesk is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-zendesk-frontend-engineer.json
+++ b/data/generated/modules/company-role-zendesk-frontend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Zendesk operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Zendesk values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Zendesk is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Zendesk is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Zendesk tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Zendesk is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zendesk values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Zendesk uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zendesk is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-zendesk-product-designer.json
+++ b/data/generated/modules/company-role-zendesk-product-designer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Zendesk operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Zendesk values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Zendesk is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Zendesk is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Zendesk tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Zendesk is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zendesk values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Zendesk uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zendesk is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-zendesk-product-manager.json
+++ b/data/generated/modules/company-role-zendesk-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Zendesk operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Zendesk values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Zendesk isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zendesk is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just t..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Zendesk tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Zendesk is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zendesk values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Zendesk uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zendesk is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-zendesk-software-engineer.json
+++ b/data/generated/modules/company-role-zendesk-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Zendesk operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is:..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Zendesk values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you ta..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Zendesk is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key update..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Zendesk uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying question..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Zendesk tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Zendesk is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zendesk values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. ..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Zendesk uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zendesk is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem ..."
           }
         }
       ]

--- a/data/generated/modules/company-role-zoom-backend-engineer.json
+++ b/data/generated/modules/company-role-zoom-backend-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Zoom operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Zoom values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Zoom is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Zoom is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Zoom tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Zoom is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zoom values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Zoom uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zoom is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-zoom-devops-engineer.json
+++ b/data/generated/modules/company-role-zoom-devops-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Zoom operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Zoom values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Zoom is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Zoom is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Zoom tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Zoom is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zoom values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Zoom uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zoom is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-zoom-engineering-manager.json
+++ b/data/generated/modules/company-role-zoom-engineering-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Zoom operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Zoom values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Zoom is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Zoom is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Zoom tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Zoom is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zoom values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Zoom uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zoom is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-zoom-product-manager.json
+++ b/data/generated/modules/company-role-zoom-product-manager.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Zoom operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Zoom values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic estimation question, but Zoom isn't looking for the right number. They're evaluating your structured thinking: Can you break a vague question into tractable pieces? Do you state assumptions explicitly? Can you sanity-check your answer? The red flag is random guessing without sho..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Walk me through how you would work with engineering to define the technical approach for a new feature.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate technical fluency (not expertise), collaborative approach with engineering, and understanding of trade-offs (speed vs. quality)",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No consideration of technical debt",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Complete deference",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Dictating technical solutions",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zoom is testing your technical fluency and collaboration style. They're not expecting you to code, but they want to see: Do you understand technical trade-offs? Can you have a productive conversation with engineers? Do you defer appropriately or try to dictate? The red flag is either 'I just tell..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Zoom tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Zoom is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zoom values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Zoom uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zoom is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-zoom-security-engineer.json
+++ b/data/generated/modules/company-role-zoom-security-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Zoom operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Zoom values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a window functions question, but Zoom is testing more than syntax. Can you think through the logic before writing? Do you handle edge cases (first purchase, gaps)? Can you explain your approach clearly? The best candidates talk through their thinking and acknowledge when they'd want to ve..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Revenue is down 10% month-over-month. How would you diagnose the cause?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Random data exploration without structure",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Not segmenting",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Jumping to conclusions without validation",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Demonstrate structured diagnostic approach, segmentation instincts, and correlation vs. causation awareness",
+                "isCorrect": true
+              }
+            ],
+            "explanation": "Zoom is testing your analytical problem-solving, not just technical skills. Can you structure a complex diagnosis? Do you segment systematically? Do you distinguish correlation from causation? The best answers show a methodical approach and acknowledge that data analysis is iterative, not linear."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Zoom tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Zoom is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zoom values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Zoom uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zoom is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/data/generated/modules/company-role-zoom-software-engineer.json
+++ b/data/generated/modules/company-role-zoom-software-engineer.json
@@ -139,6 +139,35 @@
             ],
             "explanation": "Zoom operates in uncertainty constantly. The interviewer is testing your comfort with ambiguity: Do you freeze without perfect data, or can you move forward thoughtfully? They're also watching for judgment - did you gather the RIGHT information, not just MORE information? The meta-question is: do..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Give me an example of a time you had to work with someone difficult. How did you handle it?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Making the other person the villain",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Escalating to management too quickly",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Demonstrate emotional intelligence, empathy for difficult colleagues, and constructive approach to challenges",
+                "isCorrect": true
+              },
+              {
+                "id": "d",
+                "text": "No empathy for their perspective",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "The interviewer is probing your interpersonal skills and emotional intelligence. Zoom values collaboration, but they know not everyone is easy to work with. They're watching for: Do you dismiss difficult people or try to understand them? Can you separate the person from the behavior? Do you take ..."
+          }
         }
       ]
     },
@@ -273,6 +302,35 @@
             ],
             "explanation": "This is a classic data structure problem that tests whether you can combine multiple concepts. Zoom is evaluating: Do you understand WHY this requires a hash map + doubly-linked list? Can you implement clean code under time pressure? Do you handle edge cases like capacity limits and key updates? ..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design an API for a todo list application. What endpoints would you create?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate rest convention understanding, resource-oriented thinking, and error handling consideration",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "Non-RESTful design",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Only happy path endpoints",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring pagination for list endpoints",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems simple, but Zoom uses it to probe your API design principles. They're evaluating: Do you use REST conventions correctly? Do you think about error handling and edge cases? Can you discuss versioning, pagination, and authentication? The real test is whether you ask clarifying questions o..."
+          }
         }
       ]
     },
@@ -378,6 +436,64 @@
             ],
             "explanation": "Zoom tests whether you genuinely put customers first or just say you do. The interviewer is looking for situations where customer focus created tension - with timeline, with a stakeholder, with your own priorities. They're testing: Do you cave under pressure, or find ways to serve the customer AN..."
           }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Describe your ideal work environment. What kind of culture brings out your best work?",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine self-awareness about preferences, specific examples that illustrate the ideal, and acknowledgment of trade-offs in any culture",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No acknowledgment of trade-offs",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Being too vague",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Saying what you think they want to hear",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "This seems open-ended, but Zoom is probing for authentic fit. They're watching for: Does your described ideal actually match their culture? Are you self-aware about what you need? The risk is saying what you think they want to hear - experienced interviewers spot this. It's better to be honest ab..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Tell me about a time you changed your mind on something you believed strongly.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Demonstrate genuine belief change (not trivial), evidence-based updating, and willingness to admit you were wrong",
+                "isCorrect": true
+              },
+              {
+                "id": "b",
+                "text": "No explanation of what convinced you",
+                "isCorrect": false
+              },
+              {
+                "id": "c",
+                "text": "Framing it as 'I was partly right'",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Choosing something trivial",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zoom values intellectual humility - the ability to update beliefs based on evidence. The interviewer is testing: Can you hold strong opinions loosely? Do you actually change, or just pretend to? They're watching for the quality of the new evidence and whether you sought it out or resisted it. Can..."
+          }
         }
       ]
     },
@@ -482,6 +598,35 @@
               }
             ],
             "explanation": "This question seems casual but Zoom uses it to reveal your values and intellectual curiosity. They're not judging the person you pick - they're evaluating WHY. Do you pick someone to impress (Einstein, Mandela) or someone genuinely meaningful to you? Can you articulate what you'd want to learn? T..."
+          }
+        },
+        {
+          "type": "quiz",
+          "content": {
+            "question": "Design a product for blind people to use a smartphone more easily.",
+            "options": [
+              {
+                "id": "a",
+                "text": "Assuming what blind users want without considering diversity",
+                "isCorrect": false
+              },
+              {
+                "id": "b",
+                "text": "Demonstrate user empathy for a different lived experience, research instinct (what already exists?), and problem definition before solution",
+                "isCorrect": true
+              },
+              {
+                "id": "c",
+                "text": "Jumping to solutions without understanding the problem",
+                "isCorrect": false
+              },
+              {
+                "id": "d",
+                "text": "Ignoring existing accessibility features",
+                "isCorrect": false
+              }
+            ],
+            "explanation": "Zoom is testing user empathy and structured creativity under time pressure. Can you quickly empathize with a user group you may not belong to? Do you ask clarifying questions or make assumptions? They're watching for: Do you consider existing solutions first? Can you identify the real problem bef..."
           }
         }
       ]

--- a/scripts/generate-company-role-modules.ts
+++ b/scripts/generate-company-role-modules.ts
@@ -318,19 +318,17 @@ function generateBehavioralSection(
     },
   });
 
-  // Select 3-5 questions for quizzes
-  const selectedQuestions = questions.slice(0, 5);
-
-  if (selectedQuestions.length > 0) {
+  // Use ALL questions from this category
+  if (questions.length > 0) {
     blocks.push({
       type: "tip",
       content: {
-        text: `**Key Focus Areas:** ${extractKeyThemes(selectedQuestions).join(", ")}. Prepare specific examples for each area.`,
+        text: `**Key Focus Areas:** ${extractKeyThemes(questions).join(", ")}. Prepare specific examples for each area.`,
       },
     });
 
-    // Add quiz blocks
-    for (const q of selectedQuestions.slice(0, 4)) {
+    // Add quiz blocks for ALL questions in category
+    for (const q of questions) {
       blocks.push(createQuizBlock(q));
     }
   }
@@ -360,19 +358,18 @@ function generateTechnicalSection(
     },
   });
 
-  const selectedQuestions = questions.slice(0, 5);
-
-  if (selectedQuestions.length > 0) {
+  // Use ALL questions from this category
+  if (questions.length > 0) {
     // Add a tip about technical preparation
     blocks.push({
       type: "tip",
       content: {
-        text: `**Technical Areas to Prepare:** ${extractKeyThemes(selectedQuestions).join(", ")}. Review fundamentals and practice explaining complex concepts clearly.`,
+        text: `**Technical Areas to Prepare:** ${extractKeyThemes(questions).join(", ")}. Review fundamentals and practice explaining complex concepts clearly.`,
       },
     });
 
-    // Add quiz blocks
-    for (const q of selectedQuestions.slice(0, 4)) {
+    // Add quiz blocks for ALL questions in category
+    for (const q of questions) {
       blocks.push(createQuizBlock(q));
     }
   } else {
@@ -409,9 +406,8 @@ function generateCultureSection(
     },
   });
 
-  const selectedQuestions = questions.slice(0, 5);
-
-  if (selectedQuestions.length > 0) {
+  // Use ALL questions from this category
+  if (questions.length > 0) {
     blocks.push({
       type: "warning",
       content: {
@@ -419,8 +415,8 @@ function generateCultureSection(
       },
     });
 
-    // Add quiz blocks
-    for (const q of selectedQuestions.slice(0, 3)) {
+    // Add quiz blocks for ALL questions in category
+    for (const q of questions) {
       blocks.push(createQuizBlock(q));
     }
   }
@@ -450,9 +446,8 @@ function generateCurveballSection(
     },
   });
 
-  const selectedQuestions = questions.slice(0, 4);
-
-  if (selectedQuestions.length > 0) {
+  // Use ALL questions from this category
+  if (questions.length > 0) {
     blocks.push({
       type: "tip",
       content: {
@@ -460,8 +455,8 @@ function generateCurveballSection(
       },
     });
 
-    // Add quiz blocks
-    for (const q of selectedQuestions.slice(0, 3)) {
+    // Add quiz blocks for ALL questions in category
+    for (const q of questions) {
       blocks.push(createQuizBlock(q));
     }
   }


### PR DESCRIPTION
## Summary
- Updated `generate-company-role-modules.ts` to include ALL questions from each category
- Removed `.slice()` limits in section generators that were limiting quizzes
- Regenerated all 808 company-role modules with expanded content

## Changes
- Before: 14 quizzes per module (11,312 total across all modules)
- After: 19 quizzes per module (15,352 total across all modules)
- **35% more quiz content for users**

## Test plan
- [x] npm run lint passes
- [x] npm run type-check passes
- [x] npm run build succeeds
- [x] npm test passes (12 pre-existing failures unrelated)
- [x] Module loader tests pass (23 tests)
- [x] Flatten-modules tests pass (29 tests)
- [x] Verified sample module structure

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)