### PR TITLE
Add external image hosts to Next.js config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,21 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'www.google.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'upload.wikimedia.org',
+      },
+      {
+        protocol: 'https',
+        hostname: 'www.apple.com',
+      },
+    ],
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary
- Configure Next.js to allow external images from company logo sources
- Added remote patterns for www.google.com, upload.wikimedia.org, and www.apple.com

## Test plan
- [x] Dev server runs without image host errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)