### PR TITLE
Optimize carousel cards for mobile screens

### DIFF
--- a/src/components/carousel/items/ChecklistItem.tsx
+++ b/src/components/carousel/items/ChecklistItem.tsx
@@ -32,7 +32,7 @@ const CheckIcon = () => (
 
 const ClipboardIcon = () => (
   <svg
-    className="h-8 w-8 shrink-0"
+    className="h-5 w-5 sm:h-7 sm:w-7 shrink-0"
     fill="none"
     stroke="currentColor"
     viewBox="0 0 24 24"
@@ -78,8 +78,8 @@ export function ChecklistItem({ block, onComplete, className }: ChecklistItemPro
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-center min-h-[50vh]",
-        "px-4 py-8",
+        "flex flex-col items-center justify-center min-h-[40vh] sm:min-h-[50vh]",
+        "px-3 sm:px-4 py-6 sm:py-8",
         className
       )}
     >
@@ -87,28 +87,28 @@ export function ChecklistItem({ block, onComplete, className }: ChecklistItemPro
         className={cn(
           "w-full max-w-2xl",
           "bg-blue-50 border-2 border-blue-200 rounded-2xl",
-          "p-8 sm:p-10"
+          "p-5 sm:p-8"
         )}
         role="group"
         aria-label={block.title || "Checklist"}
       >
-        <div className="flex items-start gap-4 sm:gap-6">
-          <div className="flex items-center justify-center w-14 h-14 rounded-full bg-blue-100 text-blue-600">
+        <div className="flex items-start gap-3 sm:gap-4">
+          <div className="flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-blue-100 text-blue-600 shrink-0">
             <ClipboardIcon />
           </div>
-          <div className="flex-1">
+          <div className="flex-1 min-w-0">
             {block.title && (
-              <h3 className="text-lg font-semibold text-blue-900 mb-4">
+              <h3 className="text-base sm:text-lg font-semibold text-blue-900 mb-3 sm:mb-4">
                 {block.title}
               </h3>
             )}
-            <ul className="space-y-3">
+            <ul className="space-y-2 sm:space-y-3">
               {block.items.map((item) => (
                 <li key={item.id}>
                   <label
                     className={cn(
-                      "flex items-start gap-3 cursor-pointer group",
-                      "p-3 rounded-lg transition-colors",
+                      "flex items-start gap-2.5 sm:gap-3 cursor-pointer group",
+                      "p-2 sm:p-3 rounded-lg transition-colors",
                       checkedItems.has(item.id)
                         ? "bg-blue-100"
                         : "hover:bg-blue-100/50"
@@ -116,7 +116,7 @@ export function ChecklistItem({ block, onComplete, className }: ChecklistItemPro
                   >
                     <div
                       className={cn(
-                        "flex-shrink-0 w-6 h-6 mt-0.5 rounded border-2 transition-colors",
+                        "flex-shrink-0 w-5 h-5 sm:w-6 sm:h-6 mt-0.5 rounded border-2 transition-colors",
                         "flex items-center justify-center",
                         checkedItems.has(item.id)
                           ? "bg-blue-600 border-blue-600 text-white"
@@ -135,13 +135,13 @@ export function ChecklistItem({ block, onComplete, className }: ChecklistItemPro
                     <span
                       id={`item-${item.id}-text`}
                       className={cn(
-                        "text-lg text-blue-900 leading-relaxed",
+                        "text-base sm:text-lg text-blue-900 leading-relaxed",
                         checkedItems.has(item.id) && "line-through opacity-70"
                       )}
                     >
                       {item.text}
                       {item.required === false && (
-                        <span className="ml-2 text-sm text-blue-500 font-medium">
+                        <span className="ml-1.5 sm:ml-2 text-xs sm:text-sm text-blue-500 font-medium">
                           (optional)
                         </span>
                       )}
@@ -151,8 +151,8 @@ export function ChecklistItem({ block, onComplete, className }: ChecklistItemPro
               ))}
             </ul>
             {requiredItems.length > 0 && (
-              <div className="mt-4 pt-4 border-t border-blue-200">
-                <p className="text-sm text-blue-700">
+              <div className="mt-3 sm:mt-4 pt-3 sm:pt-4 border-t border-blue-200">
+                <p className="text-xs sm:text-sm text-blue-700">
                   {allRequiredChecked ? (
                     <span className="flex items-center gap-2">
                       <CheckIcon />

--- a/src/components/carousel/items/ContentItem.tsx
+++ b/src/components/carousel/items/ContentItem.tsx
@@ -22,7 +22,7 @@ export interface ContentItemProps {
 
 const LightbulbIcon = () => (
   <svg
-    className="h-8 w-8 shrink-0"
+    className="h-5 w-5 sm:h-7 sm:w-7 shrink-0"
     fill="none"
     stroke="currentColor"
     viewBox="0 0 24 24"
@@ -39,7 +39,7 @@ const LightbulbIcon = () => (
 
 const WarningIcon = () => (
   <svg
-    className="h-8 w-8 shrink-0"
+    className="h-5 w-5 sm:h-7 sm:w-7 shrink-0"
     fill="none"
     stroke="currentColor"
     viewBox="0 0 24 24"
@@ -56,7 +56,7 @@ const WarningIcon = () => (
 
 const QuoteIcon = () => (
   <svg
-    className="h-12 w-12 text-gray-300"
+    className="h-8 w-8 sm:h-12 sm:w-12 text-gray-300"
     fill="currentColor"
     viewBox="0 0 24 24"
     aria-hidden="true"
@@ -78,15 +78,15 @@ export function ContentItem({ block, className }: ContentItemProps) {
   if (type === "header") {
     const headerBlock = block as HeaderBlock;
     const headingStyles = {
-      1: "text-4xl sm:text-5xl font-bold",
-      2: "text-3xl sm:text-4xl font-semibold",
-      3: "text-2xl sm:text-3xl font-medium",
+      1: "text-2xl sm:text-4xl font-bold",
+      2: "text-xl sm:text-3xl font-semibold",
+      3: "text-lg sm:text-2xl font-medium",
     };
 
     return (
       <div
         className={cn(
-          "flex items-center justify-center min-h-[50vh]",
+          "flex items-center justify-center min-h-[40vh] sm:min-h-[50vh]",
           "text-center px-4",
           className
         )}
@@ -104,18 +104,18 @@ export function ContentItem({ block, className }: ContentItemProps) {
     return (
       <div
         className={cn(
-          "flex flex-col items-center justify-center min-h-[50vh]",
-          "text-center px-4 py-8",
+          "flex flex-col items-center justify-center min-h-[40vh] sm:min-h-[50vh]",
+          "text-center px-4 py-6 sm:py-8",
           className
         )}
       >
         <QuoteIcon />
-        <blockquote className="mt-4 max-w-2xl">
-          <p className="text-2xl sm:text-3xl font-light text-gray-800 leading-relaxed italic">
+        <blockquote className="mt-3 sm:mt-4 max-w-2xl">
+          <p className="text-lg sm:text-2xl font-light text-gray-800 leading-relaxed italic">
             {quoteBlock.content}
           </p>
           {quoteBlock.author && (
-            <footer className="mt-6 text-lg text-gray-500 font-medium not-italic">
+            <footer className="mt-4 sm:mt-6 text-base sm:text-lg text-gray-500 font-medium not-italic">
               — {quoteBlock.author}
             </footer>
           )}
@@ -130,8 +130,8 @@ export function ContentItem({ block, className }: ContentItemProps) {
     return (
       <div
         className={cn(
-          "flex flex-col items-center justify-center min-h-[50vh]",
-          "px-4 py-8",
+          "flex flex-col items-center justify-center min-h-[40vh] sm:min-h-[50vh]",
+          "px-3 sm:px-4 py-6 sm:py-8",
           className
         )}
       >
@@ -139,20 +139,20 @@ export function ContentItem({ block, className }: ContentItemProps) {
           className={cn(
             "w-full max-w-2xl",
             "bg-green-50 border-2 border-green-200 rounded-2xl",
-            "p-8 sm:p-10"
+            "p-5 sm:p-8"
           )}
           role="note"
           aria-label="Tip"
         >
-          <div className="flex items-start gap-4 sm:gap-6">
-            <div className="flex items-center justify-center w-14 h-14 rounded-full bg-green-100 text-green-600">
+          <div className="flex items-start gap-3 sm:gap-4">
+            <div className="flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-green-100 text-green-600 shrink-0">
               <LightbulbIcon />
             </div>
-            <div className="flex-1">
-              <span className="text-sm font-semibold text-green-700 uppercase tracking-wide">
+            <div className="flex-1 min-w-0">
+              <span className="text-xs sm:text-sm font-semibold text-green-700 uppercase tracking-wide">
                 Pro Tip
               </span>
-              <div className="mt-2 text-xl sm:text-2xl text-green-900 leading-relaxed prose prose-green prose-lg">
+              <div className="mt-1.5 sm:mt-2 text-base sm:text-xl text-green-900 leading-relaxed prose prose-green prose-sm sm:prose-lg max-w-none">
                 <ReactMarkdown>{tipBlock.content}</ReactMarkdown>
               </div>
             </div>
@@ -168,8 +168,8 @@ export function ContentItem({ block, className }: ContentItemProps) {
     return (
       <div
         className={cn(
-          "flex flex-col items-center justify-center min-h-[50vh]",
-          "px-4 py-8",
+          "flex flex-col items-center justify-center min-h-[40vh] sm:min-h-[50vh]",
+          "px-3 sm:px-4 py-6 sm:py-8",
           className
         )}
       >
@@ -177,19 +177,19 @@ export function ContentItem({ block, className }: ContentItemProps) {
           className={cn(
             "w-full max-w-2xl",
             "bg-amber-50 border-2 border-amber-200 rounded-2xl",
-            "p-8 sm:p-10"
+            "p-5 sm:p-8"
           )}
           role="alert"
         >
-          <div className="flex items-start gap-4 sm:gap-6">
-            <div className="flex items-center justify-center w-14 h-14 rounded-full bg-amber-100 text-amber-600">
+          <div className="flex items-start gap-3 sm:gap-4">
+            <div className="flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-amber-100 text-amber-600 shrink-0">
               <WarningIcon />
             </div>
-            <div className="flex-1">
-              <span className="text-sm font-semibold text-amber-700 uppercase tracking-wide">
+            <div className="flex-1 min-w-0">
+              <span className="text-xs sm:text-sm font-semibold text-amber-700 uppercase tracking-wide">
                 Watch Out
               </span>
-              <div className="mt-2 text-xl sm:text-2xl text-amber-900 leading-relaxed prose prose-amber prose-lg">
+              <div className="mt-1.5 sm:mt-2 text-base sm:text-xl text-amber-900 leading-relaxed prose prose-amber prose-sm sm:prose-lg max-w-none">
                 <ReactMarkdown>{warningBlock.content}</ReactMarkdown>
               </div>
             </div>
@@ -204,13 +204,13 @@ export function ContentItem({ block, className }: ContentItemProps) {
   return (
     <div
       className={cn(
-        "flex items-center justify-center min-h-[50vh]",
-        "px-4 py-8",
+        "flex items-center justify-center min-h-[40vh] sm:min-h-[50vh]",
+        "px-3 sm:px-4 py-6 sm:py-8",
         className
       )}
     >
       <div className="w-full max-w-2xl">
-        <div className="text-xl sm:text-2xl text-gray-800 leading-relaxed prose prose-gray prose-lg max-w-none">
+        <div className="text-base sm:text-xl text-gray-800 leading-relaxed prose prose-gray prose-sm sm:prose-lg max-w-none">
           <ReactMarkdown>{textBlock.content}</ReactMarkdown>
         </div>
       </div>

--- a/src/components/carousel/items/QuizItem.tsx
+++ b/src/components/carousel/items/QuizItem.tsx
@@ -15,7 +15,7 @@ export interface QuizItemProps {
 
 const CheckIcon = () => (
   <svg
-    className="h-6 w-6"
+    className="h-5 w-5 sm:h-6 sm:w-6"
     fill="none"
     stroke="currentColor"
     viewBox="0 0 24 24"
@@ -32,7 +32,7 @@ const CheckIcon = () => (
 
 const XIcon = () => (
   <svg
-    className="h-6 w-6"
+    className="h-5 w-5 sm:h-6 sm:w-6"
     fill="none"
     stroke="currentColor"
     viewBox="0 0 24 24"
@@ -121,10 +121,10 @@ export function QuizItem({ block, onComplete, className }: QuizItemProps) {
 
   const getOptionClasses = (state: string) => {
     const base = cn(
-      "w-full p-5 sm:p-6 rounded-xl border-2 text-left",
+      "w-full p-4 sm:p-5 rounded-xl border-2 text-left",
       "transition-all duration-200",
       "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500",
-      "min-h-[64px]"
+      "min-h-[56px] sm:min-h-[64px]"
     );
 
     switch (state) {
@@ -159,19 +159,19 @@ export function QuizItem({ block, onComplete, className }: QuizItemProps) {
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-center min-h-[50vh]",
-        "px-4 py-8",
+        "flex flex-col items-center justify-center min-h-[40vh] sm:min-h-[50vh]",
+        "px-3 sm:px-4 py-6 sm:py-8",
         className
       )}
     >
-      <div className="w-full max-w-2xl space-y-8">
+      <div className="w-full max-w-2xl space-y-5 sm:space-y-8">
         {/* Question */}
-        <h2 className="text-2xl sm:text-3xl font-semibold text-gray-900 text-center leading-relaxed">
+        <h2 className="text-xl sm:text-2xl font-semibold text-gray-900 text-center leading-relaxed">
           {question}
         </h2>
 
         {/* Options */}
-        <div className="space-y-3" role="group" aria-label="Quiz options">
+        <div className="space-y-2.5 sm:space-y-3" role="group" aria-label="Quiz options">
           {options.map((option, index) => {
             const state = getOptionState(option);
             const isSelected = selectedIds.has(option.id);
@@ -188,12 +188,12 @@ export function QuizItem({ block, onComplete, className }: QuizItemProps) {
                 aria-checked={isSelected}
                 aria-disabled={isSubmitted}
               >
-                <div className="flex items-center gap-4">
+                <div className="flex items-center gap-3 sm:gap-4">
                   {/* Letter indicator */}
                   <span
                     className={cn(
                       "flex items-center justify-center shrink-0",
-                      "w-10 h-10 rounded-lg font-semibold text-lg",
+                      "w-8 h-8 sm:w-10 sm:h-10 rounded-lg font-semibold text-base sm:text-lg",
                       state === "selected" &&
                         "bg-blue-500 text-white",
                       state === "correct" &&
@@ -214,7 +214,7 @@ export function QuizItem({ block, onComplete, className }: QuizItemProps) {
                   </span>
 
                   {/* Option text */}
-                  <span className="flex-1 text-lg sm:text-xl">{option.text}</span>
+                  <span className="flex-1 text-base sm:text-lg">{option.text}</span>
                 </div>
               </button>
             );
@@ -228,10 +228,10 @@ export function QuizItem({ block, onComplete, className }: QuizItemProps) {
             onClick={handleSubmit}
             disabled={selectedIds.size === 0}
             className={cn(
-              "w-full py-4 px-6 rounded-xl font-semibold text-lg",
+              "w-full py-3 sm:py-4 px-5 sm:px-6 rounded-xl font-semibold text-base sm:text-lg",
               "transition-all duration-200",
               "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
-              "min-h-[56px]",
+              "min-h-[48px] sm:min-h-[56px]",
               selectedIds.size === 0
                 ? "bg-gray-100 text-gray-400 cursor-not-allowed"
                 : "bg-blue-600 text-white hover:bg-blue-700 shadow-lg hover:shadow-xl"
@@ -240,11 +240,11 @@ export function QuizItem({ block, onComplete, className }: QuizItemProps) {
             Check Answer
           </button>
         ) : (
-          <div className="space-y-4">
+          <div className="space-y-3 sm:space-y-4">
             {/* Result feedback */}
             <div
               className={cn(
-                "p-6 rounded-xl text-center",
+                "p-4 sm:p-6 rounded-xl text-center",
                 isCorrect
                   ? "bg-green-50 border-2 border-green-200"
                   : "bg-red-50 border-2 border-red-200"
@@ -252,10 +252,10 @@ export function QuizItem({ block, onComplete, className }: QuizItemProps) {
               role="status"
               aria-live="polite"
             >
-              <div className="flex items-center justify-center gap-3 mb-3">
+              <div className="flex items-center justify-center gap-2 sm:gap-3 mb-2 sm:mb-3">
                 <span
                   className={cn(
-                    "flex items-center justify-center w-10 h-10 rounded-full",
+                    "flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full",
                     isCorrect ? "bg-green-500 text-white" : "bg-red-500 text-white"
                   )}
                 >
@@ -263,7 +263,7 @@ export function QuizItem({ block, onComplete, className }: QuizItemProps) {
                 </span>
                 <span
                   className={cn(
-                    "text-xl font-semibold",
+                    "text-lg sm:text-xl font-semibold",
                     isCorrect ? "text-green-800" : "text-red-800"
                   )}
                 >
@@ -275,7 +275,7 @@ export function QuizItem({ block, onComplete, className }: QuizItemProps) {
               {explanation && (
                 <p
                   className={cn(
-                    "text-lg leading-relaxed",
+                    "text-base sm:text-lg leading-relaxed",
                     isCorrect ? "text-green-700" : "text-red-700"
                   )}
                 >
@@ -289,10 +289,10 @@ export function QuizItem({ block, onComplete, className }: QuizItemProps) {
               type="button"
               onClick={handleContinue}
               className={cn(
-                "w-full py-4 px-6 rounded-xl font-semibold text-lg",
+                "w-full py-3 sm:py-4 px-5 sm:px-6 rounded-xl font-semibold text-base sm:text-lg",
                 "transition-all duration-200",
                 "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2",
-                "min-h-[56px]",
+                "min-h-[48px] sm:min-h-[56px]",
                 "bg-blue-600 text-white hover:bg-blue-700 shadow-lg hover:shadow-xl"
               )}
             >


### PR DESCRIPTION
- Reduce padding (p-5 sm:p-8) and gaps for smaller screens
- Scale down icons (w-10 h-10 sm:w-12 sm:h-12) on mobile
- Reduce font sizes (text-base sm:text-lg) for better fit
- Lower min-height (40vh sm:50vh) to reduce scrolling
- Add mobile breakpoints to all interactive elements