### PR TITLE
Auto-detect port for Stripe checkout redirects

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -54,8 +54,11 @@ export async function POST(
       // User not authenticated - continue without user ID
     }
 
+    // Get base URL from request origin for redirects
+    const origin = request.headers.get('origin') || request.headers.get('referer')?.split('/').slice(0, 3).join('/');
+
     // Create checkout session
-    const result = await createCheckoutSession(validation.request, userId);
+    const result = await createCheckoutSession(validation.request, userId, origin || undefined);
 
     return NextResponse.json(result, { status: 200 });
   } catch (error) {

--- a/src/lib/stripe/checkout.ts
+++ b/src/lib/stripe/checkout.ts
@@ -9,6 +9,10 @@ import { DEFAULT_PRODUCT, type CheckoutSessionData, type CreateCheckoutRequest, 
  * Get base URL for redirects
  */
 function getBaseUrl(): string {
+  // In development, always use localhost
+  if (process.env.NODE_ENV === 'development') {
+    return process.env.DEV_BASE_URL || 'http://localhost:3000';
+  }
   // In production, use the NEXT_PUBLIC_BASE_URL or VERCEL_URL
   if (process.env.NEXT_PUBLIC_BASE_URL) {
     return process.env.NEXT_PUBLIC_BASE_URL;
@@ -16,7 +20,6 @@ function getBaseUrl(): string {
   if (process.env.VERCEL_URL) {
     return `https://${process.env.VERCEL_URL}`;
   }
-  // In development, use localhost
   return 'http://localhost:3000';
 }
 
@@ -25,10 +28,11 @@ function getBaseUrl(): string {
  */
 export async function createCheckoutSession(
   request: CreateCheckoutRequest,
-  userId?: string
+  userId?: string,
+  originUrl?: string
 ): Promise<CreateCheckoutResponse> {
   const stripe = getStripeClient();
-  const baseUrl = getBaseUrl();
+  const baseUrl = originUrl || getBaseUrl();
 
   const successUrl = request.success_url || `${baseUrl}/checkout/success?session_id={CHECKOUT_SESSION_ID}`;
   const cancelUrl = request.cancel_url || `${baseUrl}/${request.company_slug}/${request.role_slug}`;


### PR DESCRIPTION
## Summary
- Use request origin header to determine redirect URLs for Stripe checkout
- Fixes issue where dev server on non-standard ports would redirect to wrong URL

## Test plan
- [x] Checkout from localhost:3001 redirects back to localhost:3001

🤖 Generated with [Claude Code](https://claude.com/claude-code)