### PR TITLE
Change header link to Get Started for logged-out users

### DIFF
--- a/src/app/[company]/[role]/journey/JourneyContent.tsx
+++ b/src/app/[company]/[role]/journey/JourneyContent.tsx
@@ -176,10 +176,10 @@ export function JourneyContent({
               </h1>
             </div>
             <Link
-              href="/dashboard"
+              href={user ? "/dashboard" : "/login"}
               className="text-blue-600 hover:text-blue-800 font-medium"
             >
-              Dashboard
+              {user ? "Dashboard" : "Get Started"}
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Show "Get Started" (linking to /login) when logged out
- Show "Dashboard" (linking to /dashboard) when logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)