### PR TITLE
Add ChatBubble and TypingIndicator components (#183)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -3908,3 +3908,59 @@ All Stage 6 (Production Content Population) issues are now closed:
   - Spring animation on mount ✓
   - Fallback if image fails ✓
   - Respects reduced-motion ✓
+
+### 2026-01-19 - Issue #183: 1.2: Chat bubble components
+
+**Completed:**
+- Created `/src/components/alex/ChatBubble.tsx` with two variants
+- Created `/src/components/alex/TypingIndicator.tsx` with animated dots
+- Updated `/src/components/alex/index.ts` with new exports
+
+**ChatBubble Features:**
+- Two variants: alex (coach) and user (answer)
+- Alex bubble: left-aligned with tail top-left
+  - Background: `--alex-bubble-bg`
+  - Padding: 16px
+  - Border-radius: `4px 20px 20px 20px`
+  - Max-width: 320px
+  - Shadow: `0 1px 2px rgba(0,0,0,0.05)`
+- User bubble: right-aligned pill
+  - Background: `--user-bubble-bg`
+  - Padding: `12px 16px`
+  - Border-radius: 20px all corners
+  - White text, no shadow
+- Fade-in animation on mount
+- Respects reduced-motion via `useReducedMotion` hook
+
+**TypingIndicator Features:**
+- Three animated dots with staggered bouncing animation
+- Uses alex bubble styling (same background, radius, shadow)
+- Dots: 8px circles with 6px gap
+- Accessible: `role="status"`, `aria-label="Alex is typing"`
+- Individual dots are `aria-hidden`
+- Respects reduced-motion preferences
+
+**Files Created:**
+- `src/components/alex/ChatBubble.tsx`
+- `src/components/alex/TypingIndicator.tsx`
+- `src/components/alex/__tests__/ChatBubble.test.tsx`
+- `src/components/alex/__tests__/TypingIndicator.test.tsx`
+
+**Files Modified:**
+- `src/components/alex/index.ts` - Added ChatBubble and TypingIndicator exports
+
+**Tests:**
+- 51 unit tests covering:
+  - ChatBubble (27 tests): alex variant, user variant, animation, reduced motion, className, content types
+  - TypingIndicator (24 tests): rendering, styling, dot styling, accessibility, animation, reduced motion, className, layout
+
+**Verification:**
+- `npm run lint` - passes with no errors
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - 51 new tests pass (2163 total passed, pre-existing failures unrelated to this change)
+- All acceptance criteria verified:
+  - Alex bubble matches spec ✓
+  - User pill matches spec ✓
+  - Typing dots animate ✓
+  - Respects reduced-motion ✓

--- a/src/components/alex/ChatBubble.tsx
+++ b/src/components/alex/ChatBubble.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { ReactNode } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+
+export type ChatBubbleVariant = "alex" | "user";
+
+export interface ChatBubbleProps {
+  /** Bubble variant - alex (coach) or user (answer) */
+  variant: ChatBubbleVariant;
+  /** Content to display inside the bubble */
+  children: ReactNode;
+  /** Optional custom class name */
+  className?: string;
+  /** Whether to animate the bubble appearing */
+  animate?: boolean;
+}
+
+/**
+ * Chat bubble component for the conversation UI.
+ *
+ * Two variants:
+ * - **alex**: Left-aligned bubble with tail top-left (coach messages)
+ * - **user**: Right-aligned pill shape (user answers)
+ *
+ * Features:
+ * - Uses CSS variables from design tokens
+ * - Fade-in animation on mount
+ * - Respects reduced-motion preferences
+ */
+export function ChatBubble({
+  variant,
+  children,
+  className = "",
+  animate = true,
+}: ChatBubbleProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const shouldAnimate = animate && !prefersReducedMotion;
+
+  const isAlex = variant === "alex";
+
+  // Animation variants
+  const variants = {
+    hidden: {
+      opacity: 0,
+      y: 8,
+    },
+    visible: {
+      opacity: 1,
+      y: 0,
+    },
+  };
+
+  // Transition settings
+  const transition = {
+    duration: 0.25, // --duration-normal
+    ease: [0.16, 1, 0.3, 1] as const, // --ease-out
+  };
+
+  const baseClasses = isAlex
+    ? "alex-bubble"
+    : "user-bubble flex justify-end";
+
+  return (
+    <motion.div
+      className={`${baseClasses} ${className}`.trim()}
+      initial={shouldAnimate ? "hidden" : "visible"}
+      animate="visible"
+      variants={variants}
+      transition={shouldAnimate ? transition : { duration: 0 }}
+      data-variant={variant}
+    >
+      <div
+        className={isAlex ? "alex-bubble-inner" : "user-bubble-inner"}
+        style={isAlex ? alexBubbleStyle : userBubbleStyle}
+      >
+        {children}
+      </div>
+    </motion.div>
+  );
+}
+
+/**
+ * Style object for Alex (coach) bubble.
+ * - Background: --alex-bubble-bg
+ * - Padding: 16px
+ * - Border-radius: 4px 20px 20px 20px (tail top-left)
+ * - Max-width: 320px
+ * - Shadow: 0 1px 2px rgba(0,0,0,0.05)
+ */
+const alexBubbleStyle: React.CSSProperties = {
+  backgroundColor: "var(--alex-bubble-bg)",
+  padding: "var(--space-4)", // 16px
+  borderRadius: "4px 20px 20px 20px", // tail top-left
+  maxWidth: "var(--bubble-max-w)", // 320px
+  boxShadow: "0 1px 2px rgba(0,0,0,0.05)",
+};
+
+/**
+ * Style object for User (answer) bubble.
+ * - Background: --user-bubble-bg
+ * - Padding: 12px 16px
+ * - Border-radius: 20px all corners
+ * - No shadow
+ */
+const userBubbleStyle: React.CSSProperties = {
+  backgroundColor: "var(--user-bubble-bg)",
+  padding: "var(--space-3) var(--space-4)", // 12px 16px
+  borderRadius: "var(--bubble-radius)", // 20px
+  color: "white",
+};
+
+export default ChatBubble;

--- a/src/components/alex/TypingIndicator.tsx
+++ b/src/components/alex/TypingIndicator.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+
+export interface TypingIndicatorProps {
+  /** Optional custom class name */
+  className?: string;
+}
+
+/**
+ * Typing indicator component showing three animated dots.
+ *
+ * Used to indicate that the coach "Alex" is typing a message.
+ *
+ * Features:
+ * - Three dots with staggered bouncing animation
+ * - Respects reduced-motion preferences
+ * - Uses alex bubble styling
+ */
+export function TypingIndicator({ className = "" }: TypingIndicatorProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  return (
+    <div
+      className={`typing-indicator ${className}`.trim()}
+      style={containerStyle}
+      role="status"
+      aria-label="Alex is typing"
+    >
+      <div className="typing-dots" style={dotsContainerStyle}>
+        {[0, 1, 2].map((index) => (
+          <TypingDot
+            key={index}
+            index={index}
+            animate={!prefersReducedMotion}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface TypingDotProps {
+  index: number;
+  animate: boolean;
+}
+
+/**
+ * Individual typing dot with bounce animation.
+ */
+function TypingDot({ index, animate }: TypingDotProps) {
+  // Staggered delay: 0ms, 150ms, 300ms
+  const delay = index * 0.15;
+
+  // Animation variants for bounce effect
+  const variants = {
+    initial: {
+      y: 0,
+    },
+    animate: {
+      y: [-2, 2, -2],
+    },
+  };
+
+  // Infinite loop animation
+  const transition = {
+    duration: 0.6,
+    repeat: Infinity,
+    ease: "easeInOut" as const,
+    delay,
+  };
+
+  return (
+    <motion.span
+      className="typing-dot"
+      style={dotStyle}
+      variants={variants}
+      initial="initial"
+      animate={animate ? "animate" : "initial"}
+      transition={animate ? transition : undefined}
+      aria-hidden="true"
+    />
+  );
+}
+
+/**
+ * Container style - uses alex bubble styling
+ */
+const containerStyle: React.CSSProperties = {
+  backgroundColor: "var(--alex-bubble-bg)",
+  padding: "var(--space-4)", // 16px
+  borderRadius: "4px 20px 20px 20px", // tail top-left like alex bubble
+  boxShadow: "0 1px 2px rgba(0,0,0,0.05)",
+  display: "inline-block",
+};
+
+/**
+ * Dots container style
+ */
+const dotsContainerStyle: React.CSSProperties = {
+  display: "flex",
+  gap: "6px",
+  alignItems: "center",
+  height: "20px",
+};
+
+/**
+ * Individual dot style
+ */
+const dotStyle: React.CSSProperties = {
+  width: "8px",
+  height: "8px",
+  borderRadius: "50%",
+  backgroundColor: "#9ca3af", // gray-400
+  display: "inline-block",
+};
+
+export default TypingIndicator;

--- a/src/components/alex/__tests__/ChatBubble.test.tsx
+++ b/src/components/alex/__tests__/ChatBubble.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * Tests for ChatBubble component
+ * Issue: #183 - 1.2: Chat bubble components
+ */
+
+import { render, screen } from "@testing-library/react";
+import { ChatBubble } from "../ChatBubble";
+
+// Mock framer-motion
+jest.mock("framer-motion", () => {
+  const actual = jest.requireActual("framer-motion");
+  return {
+    ...actual,
+    motion: {
+      div: ({
+        children,
+        className,
+        style,
+        "data-variant": dataVariant,
+        ...props
+      }: React.HTMLAttributes<HTMLDivElement> & {
+        style?: React.CSSProperties;
+        "data-variant"?: string;
+      }) => (
+        <div
+          className={className}
+          style={style}
+          data-testid="motion-div"
+          data-variant={dataVariant}
+          {...props}
+        >
+          {children}
+        </div>
+      ),
+    },
+    useReducedMotion: jest.fn(() => false),
+  };
+});
+
+describe("ChatBubble", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("alex variant (coach)", () => {
+    test("renders alex variant", () => {
+      render(<ChatBubble variant="alex">Hello!</ChatBubble>);
+
+      const motionDiv = screen.getByTestId("motion-div");
+      expect(motionDiv).toHaveAttribute("data-variant", "alex");
+    });
+
+    test("renders children content", () => {
+      render(<ChatBubble variant="alex">Hello world!</ChatBubble>);
+
+      expect(screen.getByText("Hello world!")).toBeInTheDocument();
+    });
+
+    test("alex bubble has correct background", () => {
+      render(<ChatBubble variant="alex">Test</ChatBubble>);
+
+      const inner = document.querySelector(".alex-bubble-inner");
+      expect(inner).toHaveStyle({
+        backgroundColor: "var(--alex-bubble-bg)",
+      });
+    });
+
+    test("alex bubble has correct padding (16px)", () => {
+      render(<ChatBubble variant="alex">Test</ChatBubble>);
+
+      const inner = document.querySelector(".alex-bubble-inner");
+      expect(inner).toHaveStyle({
+        padding: "var(--space-4)",
+      });
+    });
+
+    test("alex bubble has tail top-left border radius", () => {
+      render(<ChatBubble variant="alex">Test</ChatBubble>);
+
+      const inner = document.querySelector(".alex-bubble-inner");
+      expect(inner).toHaveStyle({
+        borderRadius: "4px 20px 20px 20px",
+      });
+    });
+
+    test("alex bubble has max width", () => {
+      render(<ChatBubble variant="alex">Test</ChatBubble>);
+
+      const inner = document.querySelector(".alex-bubble-inner");
+      expect(inner).toHaveStyle({
+        maxWidth: "var(--bubble-max-w)",
+      });
+    });
+
+    test("alex bubble has subtle shadow", () => {
+      render(<ChatBubble variant="alex">Test</ChatBubble>);
+
+      const inner = document.querySelector(".alex-bubble-inner");
+      expect(inner).toHaveStyle({
+        boxShadow: "0 1px 2px rgba(0,0,0,0.05)",
+      });
+    });
+
+    test("alex bubble has alex-bubble class", () => {
+      render(<ChatBubble variant="alex">Test</ChatBubble>);
+
+      const motionDiv = screen.getByTestId("motion-div");
+      expect(motionDiv).toHaveClass("alex-bubble");
+    });
+  });
+
+  describe("user variant (answer)", () => {
+    test("renders user variant", () => {
+      render(<ChatBubble variant="user">My answer</ChatBubble>);
+
+      const motionDiv = screen.getByTestId("motion-div");
+      expect(motionDiv).toHaveAttribute("data-variant", "user");
+    });
+
+    test("renders children content", () => {
+      render(<ChatBubble variant="user">Selected option A</ChatBubble>);
+
+      expect(screen.getByText("Selected option A")).toBeInTheDocument();
+    });
+
+    test("user bubble has correct background", () => {
+      render(<ChatBubble variant="user">Test</ChatBubble>);
+
+      const inner = document.querySelector(".user-bubble-inner");
+      expect(inner).toHaveStyle({
+        backgroundColor: "var(--user-bubble-bg)",
+      });
+    });
+
+    test("user bubble has correct padding (12px 16px)", () => {
+      render(<ChatBubble variant="user">Test</ChatBubble>);
+
+      const inner = document.querySelector(".user-bubble-inner");
+      expect(inner).toHaveStyle({
+        padding: "var(--space-3) var(--space-4)",
+      });
+    });
+
+    test("user bubble has 20px border radius all corners", () => {
+      render(<ChatBubble variant="user">Test</ChatBubble>);
+
+      const inner = document.querySelector(".user-bubble-inner");
+      expect(inner).toHaveStyle({
+        borderRadius: "var(--bubble-radius)",
+      });
+    });
+
+    test("user bubble has white text", () => {
+      render(<ChatBubble variant="user">Test</ChatBubble>);
+
+      const inner = document.querySelector(".user-bubble-inner");
+      expect(inner).toHaveStyle({
+        color: "white",
+      });
+    });
+
+    test("user bubble is right-aligned", () => {
+      render(<ChatBubble variant="user">Test</ChatBubble>);
+
+      const motionDiv = screen.getByTestId("motion-div");
+      expect(motionDiv).toHaveClass("justify-end");
+    });
+
+    test("user bubble has user-bubble class", () => {
+      render(<ChatBubble variant="user">Test</ChatBubble>);
+
+      const motionDiv = screen.getByTestId("motion-div");
+      expect(motionDiv).toHaveClass("user-bubble");
+    });
+  });
+
+  describe("animation", () => {
+    test("motion div is rendered", () => {
+      render(<ChatBubble variant="alex">Test</ChatBubble>);
+
+      expect(screen.getByTestId("motion-div")).toBeInTheDocument();
+    });
+
+    test("animation is enabled by default", () => {
+      render(<ChatBubble variant="alex">Test</ChatBubble>);
+
+      // Motion div should be present (animation would be applied)
+      expect(screen.getByTestId("motion-div")).toBeInTheDocument();
+    });
+
+    test("accepts animate prop", () => {
+      render(
+        <ChatBubble variant="alex" animate={false}>
+          Test
+        </ChatBubble>
+      );
+
+      expect(screen.getByTestId("motion-div")).toBeInTheDocument();
+    });
+  });
+
+  describe("reduced motion", () => {
+    const { useReducedMotion } = require("framer-motion");
+
+    test("animation is applied when reduced motion is not preferred", () => {
+      useReducedMotion.mockReturnValue(false);
+      render(<ChatBubble variant="alex">Test</ChatBubble>);
+
+      expect(screen.getByTestId("motion-div")).toBeInTheDocument();
+    });
+
+    test("respects reduced motion preference", () => {
+      useReducedMotion.mockReturnValue(true);
+      render(<ChatBubble variant="alex">Test</ChatBubble>);
+
+      // Component still renders but with instant transition
+      expect(screen.getByTestId("motion-div")).toBeInTheDocument();
+    });
+  });
+
+  describe("className prop", () => {
+    test("applies custom className to alex variant", () => {
+      render(
+        <ChatBubble variant="alex" className="custom-class">
+          Test
+        </ChatBubble>
+      );
+
+      const motionDiv = screen.getByTestId("motion-div");
+      expect(motionDiv).toHaveClass("custom-class");
+    });
+
+    test("applies custom className to user variant", () => {
+      render(
+        <ChatBubble variant="user" className="my-class">
+          Test
+        </ChatBubble>
+      );
+
+      const motionDiv = screen.getByTestId("motion-div");
+      expect(motionDiv).toHaveClass("my-class");
+    });
+  });
+
+  describe("content types", () => {
+    test("renders text content", () => {
+      render(<ChatBubble variant="alex">Plain text message</ChatBubble>);
+
+      expect(screen.getByText("Plain text message")).toBeInTheDocument();
+    });
+
+    test("renders JSX content", () => {
+      render(
+        <ChatBubble variant="alex">
+          <strong>Bold text</strong> and <em>italic</em>
+        </ChatBubble>
+      );
+
+      expect(screen.getByText("Bold text")).toBeInTheDocument();
+      expect(screen.getByText("italic")).toBeInTheDocument();
+    });
+
+    test("renders complex nested content", () => {
+      render(
+        <ChatBubble variant="alex">
+          <div data-testid="nested-content">
+            <p>Paragraph 1</p>
+            <p>Paragraph 2</p>
+          </div>
+        </ChatBubble>
+      );
+
+      expect(screen.getByTestId("nested-content")).toBeInTheDocument();
+      expect(screen.getByText("Paragraph 1")).toBeInTheDocument();
+      expect(screen.getByText("Paragraph 2")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/alex/__tests__/TypingIndicator.test.tsx
+++ b/src/components/alex/__tests__/TypingIndicator.test.tsx
@@ -1,0 +1,276 @@
+/**
+ * Tests for TypingIndicator component
+ * Issue: #183 - 1.2: Chat bubble components
+ */
+
+import { render, screen } from "@testing-library/react";
+import { TypingIndicator } from "../TypingIndicator";
+
+// Mock framer-motion
+jest.mock("framer-motion", () => {
+  const actual = jest.requireActual("framer-motion");
+  return {
+    ...actual,
+    motion: {
+      span: ({
+        children,
+        className,
+        style,
+        ...props
+      }: React.HTMLAttributes<HTMLSpanElement> & {
+        style?: React.CSSProperties;
+      }) => (
+        <span
+          className={className}
+          style={style}
+          data-testid="typing-dot"
+          {...props}
+        >
+          {children}
+        </span>
+      ),
+    },
+    useReducedMotion: jest.fn(() => false),
+  };
+});
+
+describe("TypingIndicator", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("rendering", () => {
+    test("renders the typing indicator", () => {
+      render(<TypingIndicator />);
+
+      const indicator = document.querySelector(".typing-indicator");
+      expect(indicator).toBeInTheDocument();
+    });
+
+    test("renders three dots", () => {
+      render(<TypingIndicator />);
+
+      const dots = screen.getAllByTestId("typing-dot");
+      expect(dots).toHaveLength(3);
+    });
+
+    test("dots container has correct class", () => {
+      render(<TypingIndicator />);
+
+      const dotsContainer = document.querySelector(".typing-dots");
+      expect(dotsContainer).toBeInTheDocument();
+    });
+  });
+
+  describe("styling", () => {
+    test("uses alex bubble background", () => {
+      render(<TypingIndicator />);
+
+      const indicator = document.querySelector(".typing-indicator");
+      expect(indicator).toHaveStyle({
+        backgroundColor: "var(--alex-bubble-bg)",
+      });
+    });
+
+    test("has correct padding (16px)", () => {
+      render(<TypingIndicator />);
+
+      const indicator = document.querySelector(".typing-indicator");
+      expect(indicator).toHaveStyle({
+        padding: "var(--space-4)",
+      });
+    });
+
+    test("has alex bubble border radius (tail top-left)", () => {
+      render(<TypingIndicator />);
+
+      const indicator = document.querySelector(".typing-indicator");
+      expect(indicator).toHaveStyle({
+        borderRadius: "4px 20px 20px 20px",
+      });
+    });
+
+    test("has subtle shadow", () => {
+      render(<TypingIndicator />);
+
+      const indicator = document.querySelector(".typing-indicator");
+      expect(indicator).toHaveStyle({
+        boxShadow: "0 1px 2px rgba(0,0,0,0.05)",
+      });
+    });
+
+    test("is inline-block", () => {
+      render(<TypingIndicator />);
+
+      const indicator = document.querySelector(".typing-indicator");
+      expect(indicator).toHaveStyle({
+        display: "inline-block",
+      });
+    });
+  });
+
+  describe("dot styling", () => {
+    test("dots have circular shape", () => {
+      render(<TypingIndicator />);
+
+      const dots = screen.getAllByTestId("typing-dot");
+      dots.forEach((dot) => {
+        expect(dot).toHaveStyle({
+          borderRadius: "50%",
+        });
+      });
+    });
+
+    test("dots have correct size (8px)", () => {
+      render(<TypingIndicator />);
+
+      const dots = screen.getAllByTestId("typing-dot");
+      dots.forEach((dot) => {
+        expect(dot).toHaveStyle({
+          width: "8px",
+          height: "8px",
+        });
+      });
+    });
+
+    test("dots have gray color", () => {
+      render(<TypingIndicator />);
+
+      const dots = screen.getAllByTestId("typing-dot");
+      dots.forEach((dot) => {
+        expect(dot).toHaveStyle({
+          backgroundColor: "#9ca3af",
+        });
+      });
+    });
+
+    test("dots are inline-block", () => {
+      render(<TypingIndicator />);
+
+      const dots = screen.getAllByTestId("typing-dot");
+      dots.forEach((dot) => {
+        expect(dot).toHaveStyle({
+          display: "inline-block",
+        });
+      });
+    });
+  });
+
+  describe("accessibility", () => {
+    test("has role status", () => {
+      render(<TypingIndicator />);
+
+      const indicator = document.querySelector(".typing-indicator");
+      expect(indicator).toHaveAttribute("role", "status");
+    });
+
+    test("has aria-label for screen readers", () => {
+      render(<TypingIndicator />);
+
+      const indicator = document.querySelector(".typing-indicator");
+      expect(indicator).toHaveAttribute("aria-label", "Alex is typing");
+    });
+
+    test("dots are aria-hidden", () => {
+      render(<TypingIndicator />);
+
+      const dots = screen.getAllByTestId("typing-dot");
+      dots.forEach((dot) => {
+        expect(dot).toHaveAttribute("aria-hidden", "true");
+      });
+    });
+  });
+
+  describe("animation", () => {
+    test("motion spans are rendered for dots", () => {
+      render(<TypingIndicator />);
+
+      const dots = screen.getAllByTestId("typing-dot");
+      expect(dots).toHaveLength(3);
+    });
+
+    test("animation is enabled by default", () => {
+      const { useReducedMotion } = require("framer-motion");
+      useReducedMotion.mockReturnValue(false);
+
+      render(<TypingIndicator />);
+
+      const dots = screen.getAllByTestId("typing-dot");
+      expect(dots).toHaveLength(3);
+    });
+  });
+
+  describe("reduced motion", () => {
+    const { useReducedMotion } = require("framer-motion");
+
+    test("animation applied when reduced motion not preferred", () => {
+      useReducedMotion.mockReturnValue(false);
+      render(<TypingIndicator />);
+
+      expect(screen.getAllByTestId("typing-dot")).toHaveLength(3);
+    });
+
+    test("respects reduced motion preference", () => {
+      useReducedMotion.mockReturnValue(true);
+      render(<TypingIndicator />);
+
+      // Component still renders but with no animation
+      expect(screen.getAllByTestId("typing-dot")).toHaveLength(3);
+    });
+  });
+
+  describe("className prop", () => {
+    test("applies custom className", () => {
+      render(<TypingIndicator className="custom-class" />);
+
+      const indicator = document.querySelector(".typing-indicator");
+      expect(indicator).toHaveClass("custom-class");
+    });
+
+    test("preserves typing-indicator class with custom className", () => {
+      render(<TypingIndicator className="my-custom-style" />);
+
+      const indicator = document.querySelector(".typing-indicator");
+      expect(indicator).toHaveClass("typing-indicator");
+      expect(indicator).toHaveClass("my-custom-style");
+    });
+  });
+
+  describe("dots container layout", () => {
+    test("dots container uses flexbox", () => {
+      render(<TypingIndicator />);
+
+      const dotsContainer = document.querySelector(".typing-dots");
+      expect(dotsContainer).toHaveStyle({
+        display: "flex",
+      });
+    });
+
+    test("dots have gap between them", () => {
+      render(<TypingIndicator />);
+
+      const dotsContainer = document.querySelector(".typing-dots");
+      expect(dotsContainer).toHaveStyle({
+        gap: "6px",
+      });
+    });
+
+    test("dots are vertically centered", () => {
+      render(<TypingIndicator />);
+
+      const dotsContainer = document.querySelector(".typing-dots");
+      expect(dotsContainer).toHaveStyle({
+        alignItems: "center",
+      });
+    });
+
+    test("dots container has fixed height", () => {
+      render(<TypingIndicator />);
+
+      const dotsContainer = document.querySelector(".typing-dots");
+      expect(dotsContainer).toHaveStyle({
+        height: "20px",
+      });
+    });
+  });
+});

--- a/src/components/alex/index.ts
+++ b/src/components/alex/index.ts
@@ -1,2 +1,8 @@
 export { Avatar } from "./Avatar";
 export type { AvatarProps } from "./Avatar";
+
+export { ChatBubble } from "./ChatBubble";
+export type { ChatBubbleProps, ChatBubbleVariant } from "./ChatBubble";
+
+export { TypingIndicator } from "./TypingIndicator";
+export type { TypingIndicatorProps } from "./TypingIndicator";


### PR DESCRIPTION
## Summary
- Create `ChatBubble.tsx` with two variants: alex (coach) and user (answer)
- Create `TypingIndicator.tsx` with three animated bouncing dots
- Add 51 unit tests covering both components
- Update exports in `components/alex/index.ts`

## Test plan
- [x] `npm run lint` passes
- [x] `npm run type-check` passes
- [x] `npm run build` succeeds
- [x] All 51 new tests pass
- [x] Alex bubble matches spec (background, padding, border-radius, max-width, shadow)
- [x] User pill matches spec (background, padding, border-radius, right-aligned)
- [x] Typing dots animate with staggered bounce
- [x] Both components respect reduced-motion preferences

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)