### PR TITLE
Clean up Big Tech company modules - remove garbage Reddit scrapes (#208)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -4714,3 +4714,50 @@ All Stage 6 (Production Content Population) issues are now closed:
   - Tone is conversational and welcoming ✓
   - Explains the course structure and value prop ✓
   - Valid JSON structure matching existing section format ✓
+
+### 2026-01-19 - Issue #208: Content review: Big Tech batch
+
+**Completed:**
+- Manually reviewed and cleaned 6 Big Tech company modules
+- Removed garbage Reddit scrapes from "Common Interview Questions" sections
+- Removed garbage Reddit fragments from "Insider Tips" sections
+- Replaced with actionable, company-specific content
+
+**Companies Cleaned:**
+- Google - Removed nonsense questions like "Did you tell her about _______?"
+- Amazon - Removed "You need a back rub, my dude?" and similar fragments
+- Apple - Removed "can you even read?" and other Reddit garbage
+- Meta - Removed "When did Blind turn into Reddit?" and fragments
+- Microsoft - Removed references to wrong companies like Google in tips
+- Netflix - Removed personal diary entries and unrelated fragments
+
+**Content Replaced With:**
+- Google: Actual interview process details (4-5 interviews, hiring committee)
+- Amazon: Leadership Principles focus, Bar Raiser process, STAR method tips
+- Apple: Design thinking emphasis, on-site format, secrecy culture
+- Meta: Coding interview format, team matching process, LeetCode focus
+- Microsoft: Growth mindset emphasis, "As Appropriate" round, collaboration values
+- Netflix: Culture Memo importance, compensation discussion timing, "stunning colleagues"
+
+**Files Modified:**
+- `data/generated/modules/company-google.json` - Cleaned process/tips sections
+- `data/generated/modules/company-amazon.json` - Cleaned process/tips sections
+- `data/generated/modules/company-apple.json` - Cleaned process/tips sections
+- `data/generated/modules/company-meta.json` - Cleaned process/tips sections
+- `data/generated/modules/company-microsoft.json` - Cleaned process/tips sections
+- `data/generated/modules/company-netflix.json` - Cleaned process/tips sections
+
+**Verification:**
+- `npm run lint` - passes (only pre-existing warnings)
+- `npm run type-check` - passes with no errors
+- `npm run build` - successful production build
+- `npm test` - load-modules: 23 tests pass, flatten-modules: 29 tests pass (52 total)
+- All 6 JSON files validated
+- `grep` for garbage patterns returns 0 matches
+- All acceptance criteria verified:
+  - google - review process/tips/culture sections ✓
+  - amazon - review process/tips/culture sections ✓
+  - apple - review process/tips/culture sections ✓
+  - meta - review process/tips/culture sections ✓
+  - microsoft - review process/tips/culture sections ✓
+  - netflix - review process/tips/culture sections ✓

--- a/data/generated/modules/company-amazon.json
+++ b/data/generated/modules/company-amazon.json
@@ -186,7 +186,7 @@
         {
           "type": "text",
           "content": {
-            "text": "**Common Interview Questions:**\n\n- \"* “When can you start?\"\n- \"(Unless there's a huge problem.)\n* “How much money do you want?\"\n- \"You need a back rub, my dude?\"\n- \"in these sections?\"\n- \"explain away a gap in my work history on my resume?\""
+            "text": "**What to Expect:**\n\n- Initial phone screen with recruiter\n- Loop interviews focus heavily on Leadership Principles\n- Each interviewer typically owns 2-3 Leadership Principles to assess\n- Bar Raiser interview to maintain hiring standards\n- Expect deep-dive behavioral questions with STAR format"
           }
         },
         {
@@ -237,7 +237,7 @@
         {
           "type": "text",
           "content": {
-            "text": "**Insider Tips:**\n\n- here (question #1) that's the best I can give\n- your LinkedIn profile is spruced up and filled out so you get poached by recruiters (it should match your resume pretty closely in content)\n- it's not cookie-cutter\n- you know 95% of the questions coming at you before they're asked\n- they know you're also someone they'd like spending time with every day"
+            "text": "**Insider Tips:**\n\n- Memorize and understand all 16 Leadership Principles deeply\n- Prepare 2-3 strong examples for each Leadership Principle\n- Use specific metrics and data in your STAR stories\n- Be ready to explain trade-offs and decisions you made\n- Research the specific team's products and recent launches"
           }
         },
         {

--- a/data/generated/modules/company-apple.json
+++ b/data/generated/modules/company-apple.json
@@ -186,7 +186,7 @@
         {
           "type": "text",
           "content": {
-            "text": "**Common Interview Questions:**\n\n- \"can you even read?\"\n- \"Why is that relevant to me or this job?\"\n- \"You just mentioned that you oversee two teams and nothing else. Can you elaborate a bit more about what teams you manage?\"\n- \"The job role description was a bit generic, can you please elaborate about the job role and what team the position is for?\"\n- \"Can you then tell me about the verification environment you use and what the day-to-day job role might look like?\""
+            "text": "**What to Expect:**\n\n- Initial recruiter call followed by technical phone screen\n- On-site typically includes 5-8 interviews in one day\n- Strong emphasis on design thinking and user experience\n- Expect questions about why you want to work at Apple specifically\n- Process known for high secrecy - limited info shared about roles"
           }
         },
         {
@@ -237,7 +237,7 @@
         {
           "type": "text",
           "content": {
-            "text": "**Insider Tips:**\n\n- making friends with people in your class, or finding somebody else with a strong network and free-loading off of theirs (and buy them lunch or somethi\n- on what is going to be on the interview/what the hiring manager is like, etc\n- from someone with good tips &amp; actual success when applying to jobs gets downvoted but posts like \"I applied to 700 places and finally got an offer\n- to not sound arrogant\n- you *accept* in writing an offer from apple first before you tell your current boss"
+            "text": "**Insider Tips:**\n\n- Demonstrate genuine passion for Apple products and design\n- Be prepared to discuss attention to detail in your past work\n- Show how you think about end-user experience\n- Apple values collaboration - prepare examples of cross-functional work\n- Research the specific product area you're interviewing for"
           }
         },
         {

--- a/data/generated/modules/company-google.json
+++ b/data/generated/modules/company-google.json
@@ -186,7 +186,7 @@
         {
           "type": "text",
           "content": {
-            "text": "**Common Interview Questions:**\n\n- \"Did you tell her about _______?\"\n- \"Is she okay with _________?\"\n- \"Does she understand _________?\"\n- \"Bubble or Revolution?\"\n- \"what and why are you studying?\""
+            "text": "**What to Expect:**\n\n- Phone screen with recruiter followed by technical screen\n- On-site typically includes 4-5 interviews\n- Mix of coding, system design, and behavioral questions\n- Hiring committee reviews all feedback before decision\n- Process can take 4-8 weeks from application to offer"
           }
         },
         {
@@ -237,7 +237,7 @@
         {
           "type": "text",
           "content": {
-            "text": "**Insider Tips:**\n\n- and training (and *not* based on that awful overly formal AI writing style everyone hates), and give you multiple suggestions to choose from for bette\n- in general, just PM me and I'll try to get back to you before long\n- is helping so many people; the comments have totally made my day\n- putting personal interests on a resume\n- is only going to create more of those"
+            "text": "**Insider Tips:**\n\n- Practice explaining your thought process out loud during coding\n- Use the STAR method for behavioral questions with specific metrics\n- Research your interviewers on LinkedIn beforehand if possible\n- Prepare thoughtful questions about the team and product\n- Ask about day-to-day work and team dynamics"
           }
         },
         {

--- a/data/generated/modules/company-meta.json
+++ b/data/generated/modules/company-meta.json
@@ -186,7 +186,7 @@
         {
           "type": "text",
           "content": {
-            "text": "**Common Interview Questions:**\n\n- \"When did Blind turn into Reddit?\"\n- \"you need to gain some skills before you can get a living wage. Have you tried moving out into   the farthest end of North Dakota and working on an oil rig for two years?\"\n- \"What does a Creative Writer at Meta even mean?\"\n- \"I'm waiting for the interview. When will you call me? Or is there a link?\"\n- \"how would you solve the same problem without parent pointers but with the root node instead?\""
+            "text": "**What to Expect:**\n\n- Initial recruiter screen followed by technical phone screen\n- On-site loop typically includes 2 coding rounds plus system design\n- Behavioral round focuses on 'Move Fast' and collaboration\n- Coding interviews emphasize optimal solutions and clean code\n- Team matching happens after passing the loop"
           }
         },
         {
@@ -237,7 +237,7 @@
         {
           "type": "text",
           "content": {
-            "text": "**Insider Tips:**\n\n- I could give for the sake of mental health it is this\n- this sequence of processing coding problems as it really helped me:\n- or a structured set of expectations for what interviewers expect you to be able to accomplish? I just don't know where to start\n- interviewer agrees with your approach before coding\n- is don’t try to get pushed up too soon"
+            "text": "**Insider Tips:**\n\n- Practice LeetCode medium/hard problems extensively before the interview\n- Communicate your approach before coding - get interviewer buy-in\n- Meta values speed and iteration - show you can move fast\n- Prepare examples of impact at scale for behavioral questions\n- Research the product area you're interested in joining"
           }
         },
         {

--- a/data/generated/modules/company-microsoft.json
+++ b/data/generated/modules/company-microsoft.json
@@ -186,7 +186,7 @@
         {
           "type": "text",
           "content": {
-            "text": "**Common Interview Questions:**\n\n- \"will i ever make it to GOOGLE if i don't go to Stanford!?\"\n- \"I was looking at the recent announcement from [YOUR AMAZING COMPANY], how do you feel about it?\"\n- \"I saw that blog post your team did on BigQuery, what were some of the challenges you guys faced in refactoring your pipelines?\"\n- \"Do you realize this is a software interview?\"\n- \"Good, that's what we're looking for.  Now you realize if you get this position, you have to be able to program?\""
+            "text": "**What to Expect:**\n\n- Initial recruiter screen to discuss role and experience\n- Technical phone screen with coding or system design\n- On-site loop with 4-5 interviews including 'As Appropriate' final round\n- Mix of coding, design, and behavioral questions\n- Each interviewer provides independent feedback to hiring committee"
           }
         },
         {
@@ -237,7 +237,7 @@
         {
           "type": "text",
           "content": {
-            "text": "**Insider Tips:**\n\n- using a dictionary is the most common way to get from a brute force approach to something more clever\n- or even coaching, you can try emailing me at suryc011 [at] gmail [dot] com\n- to schedule 4+ weeks of vacation well ahead of time\n- you get the time off ahead of time, and then schedule your vacation before paying for anything\n- that you know what you're doing"
+            "text": "**Insider Tips:**\n\n- Demonstrate growth mindset - Microsoft values learning and curiosity\n- Research the specific product team and recent launches\n- Be prepared to discuss how you handle ambiguity and complexity\n- Show collaboration skills - Microsoft emphasizes teamwork\n- Prepare questions about team culture and work-life balance"
           }
         },
         {

--- a/data/generated/modules/company-netflix.json
+++ b/data/generated/modules/company-netflix.json
@@ -186,7 +186,7 @@
         {
           "type": "text",
           "content": {
-            "text": "**Common Interview Questions:**\n\n- \"How are you doing on ____ topic?\"\n- \"Great can you explain how ____ works?\"\n- \"Is this something you brought up?\"\n- \"“how do you know which priorities to work on first?\"\n- \"explain how ____ works?\""
+            "text": "**What to Expect:**\n\n- Initial recruiter call to assess culture fit\n- Phone screen with hiring manager often comes early in process\n- On-site loop typically spans multiple days with various stakeholders\n- Heavy emphasis on Netflix culture and values throughout\n- Compensation discussion happens early - they ask for desired salary upfront"
           }
         },
         {
@@ -237,7 +237,7 @@
         {
           "type": "text",
           "content": {
-            "text": "**Insider Tips:**\n\n- I have lunch and breakfast prepped, get on the highway, drive, get there at 8:15, mindless chit chat till 8:30, join the same useless meeting on zoom\n- after a decade in tech\n- about more passive approaches like ETFs and index funds\n- these students to my friends who are in the industry\n- to future/current bootcamp students**"
+            "text": "**Insider Tips:**\n\n- Read the Netflix Culture Memo thoroughly - they will ask about it\n- Be prepared to discuss difficult decisions and how you handled them\n- Netflix values 'stunning colleagues' - show exceptional competence\n- Demonstrate candid communication style - they value direct feedback\n- Research compensation expectations beforehand as they ask early"
           }
         },
         {


### PR DESCRIPTION
## Summary
- Manually reviewed and cleaned 6 Big Tech company modules
- Removed garbage Reddit scrapes from "Common Interview Questions" and "Insider Tips" sections
- Replaced with actionable, company-specific content

## Companies Cleaned
- **Google** - Removed nonsense like "Did you tell her about _______?", replaced with actual process details
- **Amazon** - Removed "You need a back rub, my dude?", added Leadership Principles focus
- **Apple** - Removed "can you even read?", added design thinking emphasis
- **Meta** - Removed "When did Blind turn into Reddit?", added coding interview details
- **Microsoft** - Removed references to wrong companies, added growth mindset tips
- **Netflix** - Removed personal diary entries, added Culture Memo importance

## Test plan
- [x] All 6 JSON files validate with `jq`
- [x] `npm run lint` passes
- [x] `npm run type-check` passes
- [x] `npm run build` passes
- [x] Module tests pass (load-modules: 23, flatten-modules: 29)
- [x] `grep` for garbage patterns returns 0 matches

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)