### PR TITLE
Add Google Analytics (GA4) tracking

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from "next";
 import { Poppins } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import { Providers } from "./providers";
 import { getServerSession } from "@/lib/supabase/server";
 import { Header, Footer } from "@/components/layout";
+
+const GA_MEASUREMENT_ID = "G-5CV48VST48";
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -25,6 +28,18 @@ export default async function RootLayout({
 
   return (
     <html lang="en">
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_MEASUREMENT_ID}');
+        `}
+      </Script>
       <body className={poppins.className}>
         <Providers initialSession={session}>
           <div className="min-h-screen flex flex-col">


### PR DESCRIPTION
- Add gtag.js script with measurement ID G-5CV48VST48
- Use Next.js Script component with afterInteractive strategy for performance